### PR TITLE
Take a first pass at defining typography.

### DIFF
--- a/docs/form.md
+++ b/docs/form.md
@@ -1,8 +1,8 @@
-Form is where brand comes into play. It's how colour, type, and other visual styling choices are applied to the components in Function. It's about brand expression, polish, identity, uniqueness, emotion, beauty. Form is the part of design people tend to think of when you say "design," and it only really comes into play once the Foundation and Function are solid. It's the skin that makes the apple look delicious, to mix a metaphor.
+Form is where brand comes into play. It's how colour, type, and other visual styling choices are applied to the components in Function. It's about brand expression, polish, identity, uniqueness, emotion, and beauty. Form is the part of design people tend to think of when you say "design," and it only really comes into play once the Foundation and Function are solid. It's the skin that makes the apple look delicious, to mix a metaphor.
 
-Form is where brand expression and beauty comes into play: essentially themeing, it's how visual styling is applied to the Functional components making use of the core rules and variables provided by the Foundation.
+Form is where brand expression and beauty comes into play: essentially theming, it's how visual styling is applied to the Functional components making use of the core rules and variables provided by the Foundation.
 
 Foundation → Form
-$pink-500: #D1478E; → $color-accent: $pink-500;
+`$pink-500: #D1478E;` → `$color-accent: $pink-500;`
 
 Form is about brand tokens. It also allows for per-brand overrides, because sometimes you just need to be a special snowflake.

--- a/docs/form.md
+++ b/docs/form.md
@@ -1,0 +1,8 @@
+Form is where brand comes into play. It's how colour, type, and other visual styling choices are applied to the components in Function. It's about brand expression, polish, identity, uniqueness, emotion, beauty. Form is the part of design people tend to think of when you say "design," and it only really comes into play once the Foundation and Function are solid. It's the skin that makes the apple look delicious, to mix a metaphor.
+
+Form is where brand expression and beauty comes into play: essentially themeing, it's how visual styling is applied to the Functional components making use of the core rules and variables provided by the Foundation.
+
+Foundation → Form
+$pink-500: #D1478E; → $color-accent: $pink-500;
+
+Form is about brand tokens. It also allows for per-brand overrides, because sometimes you just need to be a special snowflake.

--- a/docs/foundation.md
+++ b/docs/foundation.md
@@ -1,0 +1,10 @@
+Foundation is where everything begins. 
+
+It starts with a set of principles to guide and shape our work. 
+
+It then includes a set of core design tokens (colours, type styles, etc) as a library. These tokens are then applied in the Form section to apply brand preferences.
+
+Foundation → Form
+$pink-500: #D1478E; → $color-accent: $pink-500;
+
+So the colour ramps would belong in Foundation, whereas accent colours belong to Form. In css structure, this becomes the overriddable stuff, which theoretically makes for a more robustly flexible system. 

--- a/docs/foundation.md
+++ b/docs/foundation.md
@@ -5,6 +5,6 @@ It starts with a set of principles to guide and shape our work.
 It then includes a set of core design tokens (colours, type styles, etc) as a library. These tokens are then applied in the Form section to apply brand preferences.
 
 Foundation → Form
-$pink-500: #D1478E; → $color-accent: $pink-500;
+`$pink-500: #D1478E;` → `$color-accent: $pink-500;`
 
-So the colour ramps would belong in Foundation, whereas accent colours belong to Form. In css structure, this becomes the overriddable stuff, which theoretically makes for a more robustly flexible system. 
+So the colour ramps would belong in Foundation, whereas accent colours belong to Form. In CSS structure, this becomes the overriddable stuff, which theoretically makes for a more robustly flexible system. 

--- a/docs/function.md
+++ b/docs/function.md
@@ -1,0 +1,8 @@
+Function is a collection of functional patterns, defined as much as possible by their function.
+
+We reference these in three layers:
+- components (buttons, headings) make up the smallest unit
+- patterns (cards, navigation) are comprised of components pieced together
+- layouts (search results, article page) are full-page layouts comprising of patterns and components
+
+Function provides a series of components and patterns with a defined behaviour. Basically, if something is a React component, it's going to be in here. And basically everything is a React component, so if you're looking to build something, start here. 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,5 +1,37 @@
-### Hello 
-
 Nautilus is a design system, built for flexibility, efficiency, and beauty. 
 
 Nautilus is based in part on [Ether](https://ether.thescenery.co), with heavy contributions from an array of other design systems. It's a perpetual work in progress that is currently very much in progress. If you'd like to use it  for something, feel free! If you'd like to fork it and make something new, you can do that too. Nautilus is open-source, open-design, and open to contributions. Feel free to file an issue or open a PR [on Github](https://github.com/octopusthink/nautilus) if you notice anything amiss, or if you'd just like to say hi! 👋
+
+Nautilus is structured into three sections:
+
+## Foundation 
+
+Principles, guidelines, core design tokens.
+
+_Example: colour palettes_
+
+Start here if you're just getting started.
+
+## Function 
+
+Components, patterns, and layouts. Everything that's a React component. Function provides a series of components and patterns with a defined behaviour. 
+
+_Example: a button or a card_
+
+Start here if you're looking to build something right away.
+
+## Form 
+
+Form is brand expression, polish, identity, uniqueness, emotion, beauty. Form is where brand expression and beauty comes into play: essentially themeing, it's how visual styling is applied to the Functional components making use of the core rules and variables provided by the Foundation.
+
+_Example: primary colour, border-radius_
+
+Start here if you're looking to take your app/site and make it your own.
+
+## So how does it all fit together?
+
+So the colour ramps would belong in Foundation, whereas accent colours belong to Form. In css structure, this becomes the overriddable stuff, which theoretically makes for a more robustly flexible system. 
+
+So, for instance, Foundation provides a core set of colour palettes with a wide range. 
+
+This will make a whole lot more sense once the system is  a bit more fleshed out, but for now, just trust me that it'll all make  sense in time, and once there's a diagram.

--- a/docs/typographyVariables.md
+++ b/docs/typographyVariables.md
@@ -1,0 +1,167 @@
+Located at: [/src/base/typography/typographyVariables.js](https://github.com/wearethescenery/ether-system-react/blob/master/src/base/color/typographyVariables.js)
+
+
+Naming here is important?
+
+base colours + brand colours?
+colour library + colour tokens?
+library tokens + brand tokens?
+(read more about design tokens first!)
+
+base, brand, belts-and-braces
+
+foundation, studs/rebar/walls, trim/paint/shingles
+
+core, components/flesh, skin (like an apple)
+
+rename files and code to match
+
+building code is helpful—because the code needs to match the mental model and structure (and structure in Sketch) in order for the system to work on both ends
+
+
+
+```js noeditor
+const colors = require('../src/base/color/colors');
+const colorVariables = require('../src/base/color/colorVariables');
+
+const { VariableTable } = require('../styleguide-ui/VariableTable');
+<VariableTable baseVariables={colors} brandVariables={colorVariables} />
+```
+
+
+```css
+PageTitle {
+  font-family: HarrietDisplay;
+  font-size: 64px;
+  font-weight: bold;
+  font-style: normal;
+  font-stretch: normal;
+  line-height: 1;
+  letter-spacing: normal;
+  color: #000000;
+}
+
+.HeadingLarge {
+  font-family: HarrietDisplay;
+  font-size: 51px;
+  font-weight: bold;
+  font-style: normal;
+  font-stretch: normal;
+  line-height: 1.29;
+  letter-spacing: normal;
+  color: #000000;
+}
+
+.HeadingMedium {
+  font-family: HarrietDisplay;
+  font-size: 41px;
+  font-weight: bold;
+  font-style: normal;
+  font-stretch: normal;
+  line-height: 1.61;
+  letter-spacing: normal;
+  color: #000000;
+}
+
+.HeadingSmall {
+  font-family: HarrietDisplay;
+  font-size: 33px;
+  font-weight: 500;
+  font-style: normal;
+  font-stretch: normal;
+  line-height: 1.12;
+  letter-spacing: normal;
+  color: #000000;
+}
+
+.BodyLarge {
+  font-family: HarrietText;
+  font-size: 32.2px;
+  font-weight: normal;
+  font-style: normal;
+  font-stretch: normal;
+  line-height: 1.43;
+  letter-spacing: normal;
+  color: #000000;
+}
+
+.InterfaceLarge {
+  font-family: SFUIText;
+  font-size: 32.2px;
+  font-weight: normal;
+  font-style: normal;
+  font-stretch: normal;
+  line-height: 2.05;
+  letter-spacing: normal;
+  color: #000000;
+}
+
+.Subheading {
+  font-family: HarrietText;
+  font-size: 26px;
+  font-weight: 300;
+  font-style: italic;
+  font-stretch: normal;
+  line-height: 1.04;
+  letter-spacing: normal;
+  color: #000000;
+}
+
+.InterfaceMedium {
+  font-family: SFUIText;
+  font-size: 24.8px;
+  font-weight: normal;
+  font-style: normal;
+  font-stretch: normal;
+  line-height: 2.67;
+  letter-spacing: normal;
+  color: #000000;
+}
+
+.BodyMedium {
+  font-family: HarrietText;
+  font-size: 18px;
+  font-weight: normal;
+  font-style: normal;
+  font-stretch: normal;
+  line-height: 2;
+  letter-spacing: normal;
+  color: #000000;
+}
+
+.InterfaceSmall {
+  font-family: SFUIText;
+  font-size: 17px;
+  font-weight: 600;
+  font-style: normal;
+  font-stretch: normal;
+  line-height: 1.59;
+  letter-spacing: 0.5px;
+  color: #000000;
+}
+
+.BodySmall {
+  font-family: HarrietText;
+  font-size: 16px;
+  font-weight: normal;
+  font-style: normal;
+  font-stretch: normal;
+  line-height: 1.69;
+  letter-spacing: normal;
+  color: #000000;
+}
+
+.MetadataSmall {
+  font-family: SFUIText;
+  font-size: 15px;
+  font-weight: 600;
+  font-style: normal;
+  font-stretch: normal;
+  line-height: 1.8;
+  letter-spacing: 0.4px;
+  color: #000000;
+}
+````
+
+
+

--- a/src/base/spacing.js
+++ b/src/base/spacing.js
@@ -8,31 +8,26 @@
 // fontCapHeight is defined as the x-height of the base0 font size
 // ----------------------------------------
 
-// Create spacing sizes tied to typography
-
-const fontCapHeight = 0.9; // Cap-height of the base0 font size
-const sizeModifier = fontCapHeight * 10; // used to convert to px in the end
-
-// Calculate individual spacer heights/widths
+// Spacers follow a geometric pattern based on a grid of 8pt
 const spacerNone = 0;
-const spacer2xs = Math.round(sizeModifier * 0.5); // 5px
-const spacerXs = sizeModifier; // 9px
-const spacerSm = Math.round(sizeModifier * 1.5); // 14px
-const spacerMd = Math.round(sizeModifier * 2.5); // 23px
-const spacerLg = Math.round(sizeModifier * 4); // 36px
-const spacerXl = Math.round(sizeModifier * 6.5); // 59px
-const spacer2xl = Math.round(sizeModifier * 10.5); // 95px
+const spacerxxs = 4;
+const spacerXs = 8;
+const spacerSm = 16;
+const spacerMd = 32;
+const spacerLg = 48;
+const spacerXl = 64;
+const spacerxxl = 80;
 
-// Spacer Options
+// Output spacing in rem units so as to scale with type
 const spacerSizes = {
-  'none': `${spacerNone}px`,
-  '2xsmall': `${spacer2xs}px`,
-  'xsmall': `${spacerXs}px`,
-  'small': `${spacerSm}px`,
-  'medium': `${spacerMd}px`,
-  'large': `${spacerLg}px`,
-  'xlarge': `${spacerXl}px`,
-  '2xlarge': `${spacer2xl}px`,
+  'none': `${spacerNone}rem`,
+  'xxsmall': `${spacerxxs/10}rem`,
+  'xsmall': `${spacerXs/10}rem`,
+  'small': `${spacerSm/10}rem`,
+  'medium': `${spacerMd/10}rem`,
+  'large': `${spacerLg/10}rem`,
+  'xlarge': `${spacerXl/10}rem`,
+  'xxlarge': `${spacerxxl/10}rem`,
 };
 
 export default spacerSizes;

--- a/src/base/typography/fontSizes.js
+++ b/src/base/typography/fontSizes.js
@@ -25,6 +25,11 @@ const desktopSize4 = (Math.round(desktopSize3 * 10 * desktopScale)) / 10; // XL 
 const desktopSize5 = (Math.round(desktopSize4 * 10 * desktopScale)) / 10; // XXL Heading
 const desktopSize6 = (Math.round(desktopSize5 * 10 * desktopScale)) / 10; // XXXL Heading
 
+const smallCapsModifier = 0.7; // Small-caps modifier.
+const desktopSize0SC = (Math.round(desktopSize0 * 10 * desktopScale * smallCapsModifier)) / 10; // Body + Small Heading
+const desktopSize1SC = (Math.round(desktopSize1 * 10 * desktopScale * smallCapsModifier)) / 10; // Body + Small Heading
+
+
 const mobileSize0 = 1.6; // Fine Print + XS Heading
 const mobileSize1 = mobileSize0 * mobileScale; // Body + Small Heading
 const mobileSize2 = mobileSize1 * mobileScale; // Large Body + Heading
@@ -46,6 +51,18 @@ const fontSizes = {
     font-size: ${mobileSize1}rem;
     ${mediaQueries.sm} {
       font-size: ${desktopSize1}rem;
+    }
+  `,
+  size0SC: css`
+    font-size: ${mobileSize0}rem;
+    ${mediaQueries.sm} {
+      font-size: ${desktopSize0SC}rem;
+    }
+  `,
+  size1SC: css`
+    font-size: ${mobileSize1}rem;
+    ${mediaQueries.sm} {
+      font-size: ${desktopSize1SC}rem;
     }
   `,
   size2: css`

--- a/src/base/typography/fontSizes.js
+++ b/src/base/typography/fontSizes.js
@@ -3,8 +3,8 @@
 //
 // https://ether.thescenery.co/typography/
 //
-// The font-size value is in ex units.
-// For more information on this unit, see https://developer.mozilla.org/en-US/docs/Web/CSS/length#ex
+// The font-size value is in rem units.
+// For more information on this unit, see https://developer.mozilla.org/en-US/docs/Web/CSS/length#rem
 //
 
 import { css } from 'styled-components';
@@ -12,68 +12,70 @@ import { css } from 'styled-components';
 import mediaQueries from '../breakpoints';
 
 // Edit these scale values to generate all system sizes. Add or remove as many as your system needs.
-const desktopScale = 1.3; // Desktop scale modifier
-const mobileScale = 1.28; // Mobile scale modifier
+const desktopScale = 1.25; // Desktop scale modifier
+const mobileScale = 1.15; // Mobile scale modifier
 
-const dBase0 = 2.8; // Fine Print + XS Heading
-const dBase1 = dBase0 * desktopScale; // Body + Small Heading
-const dBase2 = dBase1 * desktopScale; // Large Body + Heading
-const dBase3 = dBase2 * desktopScale; // Large Heading
-const dBase4 = dBase3 * desktopScale; // XL Heading
-const dBase5 = dBase4 * desktopScale; // XXL Heading
-const dBase6 = dBase5 * desktopScale; // XXXL Heading
+const desktopSize0 = 1.7; // Fine Print + XS Heading
+// In order to get a whole-integer pixel number, we multiply by ten and round,
+// then divide by ten again to get a rem value that works with our base size setting.
+const desktopSize1 = (Math.round(desktopSize0 * 10 * desktopScale)) / 10; // Body + Small Heading
+const desktopSize2 = (Math.round(desktopSize1 * 10 * desktopScale)) / 10; // Large Body + Heading
+const desktopSize3 = (Math.round(desktopSize2 * 10 * desktopScale)) / 10; // Large Heading
+const desktopSize4 = (Math.round(desktopSize3 * 10 * desktopScale)) / 10; // XL Heading
+const desktopSize5 = (Math.round(desktopSize4 * 10 * desktopScale)) / 10; // XXL Heading
+const desktopSize6 = (Math.round(desktopSize5 * 10 * desktopScale)) / 10; // XXXL Heading
 
-const mBase0 = 1.7; // Fine Print + XS Heading
-const mBase1 = mBase0 * mobileScale; // Body + Small Heading
-const mBase2 = mBase1 * mobileScale; // Large Body + Heading
-const mBase3 = mBase2 * mobileScale; // Large Heading
-const mBase4 = mBase3 * mobileScale; // XL Heading
-const mBase5 = mBase4 * mobileScale; // XXL Heading
-const mBase6 = mBase5 * mobileScale; // XXXL Heading
+const mobileSize0 = 1.6; // Fine Print + XS Heading
+const mobileSize1 = mobileSize0 * mobileScale; // Body + Small Heading
+const mobileSize2 = mobileSize1 * mobileScale; // Large Body + Heading
+const mobileSize3 = mobileSize2 * mobileScale; // Large Heading
+const mobileSize4 = mobileSize3 * mobileScale; // XL Heading
+const mobileSize5 = mobileSize4 * mobileScale; // XXL Heading
+const mobileSize6 = mobileSize5 * mobileScale; // XXXL Heading
 
 // Create font-size values from calculated scale/base values above
 // Media queries are optional, but we recommend them for better font control at smaller resolutions
 const fontSizes = {
   size0: css`
-    font-size: ${mBase0}ex;
+    font-size: ${mobileSize0}rem;
     ${mediaQueries.sm} {
-      font-size: ${dBase0}ex;
+      font-size: ${desktopSize0}rem;
     }
   `,
   size1: css`
-    font-size: ${mBase1}ex;
+    font-size: ${mobileSize1}rem;
     ${mediaQueries.sm} {
-      font-size: ${dBase1}ex;
+      font-size: ${desktopSize1}rem;
     }
   `,
   size2: css`
-    font-size: ${mBase2}ex;
+    font-size: ${mobileSize2}rem;
     ${mediaQueries.sm} {
-      font-size: ${dBase2}ex;
+      font-size: ${desktopSize2}rem;
     }
   `,
   size3: css`
-    font-size: ${mBase3}ex;
+    font-size: ${mobileSize3}rem;
     ${mediaQueries.sm} {
-      font-size: ${dBase3}ex;
+      font-size: ${desktopSize3}rem;
     }
   `,
   size4: css`
-    font-size: ${mBase4}ex;
+    font-size: ${mobileSize4}rem;
     ${mediaQueries.sm} {
-      font-size: ${dBase4}ex;
+      font-size: ${desktopSize4}rem;
     }
   `,
   size5: css`
-    font-size: ${mBase5}ex;
+    font-size: ${mobileSize5}rem;
     ${mediaQueries.sm} {
-      font-size: ${dBase5}ex;
+      font-size: ${desktopSize5}rem;
     }
   `,
   size6: css`
-    font-size: ${mBase6}ex;
+    font-size: ${mobileSize6}rem;
     ${mediaQueries.sm} {
-      font-size: ${dBase6}ex;
+      font-size: ${desktopSize6}rem;
     }
   `,
 };

--- a/src/base/typography/fonts.js
+++ b/src/base/typography/fonts.js
@@ -41,7 +41,7 @@ const fonts = {
   bodyItalic: css`
     font-family: "Harriet Text", Georgia, serif;
     font-style: italic;
-    font-weight: 300;
+    font-weight: 400;
   `,
   bodyRegular: css`
     font-family: "Harriet Text", Georgia, serif;
@@ -51,7 +51,17 @@ const fonts = {
   bodyBold: css`
     font-family: "Harriet Text", Georgia, serif;
     font-style: normal;
-    font-weight: 400;
+    font-weight: 500;
+  `,
+  interfaceRegular: css`
+    font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+    font-style: normal;
+    font-weight: 300;
+  `,
+  interfaceBold: css`
+    font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+    font-style: normal;
+    font-weight: 500;
   `,
 };
 

--- a/src/base/typography/typography.js
+++ b/src/base/typography/typography.js
@@ -38,12 +38,14 @@ const typography = {
     line-height: 1.4;
   `,
   headingXSmall: css`
-    ${fonts.primaryLight};
+    ${fonts.interfaceBold};
     ${fontSizes.size1};
-    line-height: 1.4;
+    letter-spacing: 1px;
+    line-height: 1.2;
+    text-transform: uppercase;
   `,
   headingXXSmall: css`
-    ${fonts.primaryLight};
+    ${fonts.interfaceBold};
     ${fontSizes.size0};
     letter-spacing: 1px;
     line-height: 1.2;

--- a/src/base/typography/typography.js
+++ b/src/base/typography/typography.js
@@ -9,6 +9,7 @@ import { css } from 'styled-components';
 
 import fonts from './fonts';
 import fontSizes from './fontSizes';
+import spacerSizes from './../spacing';
 
 const typography = {
   // Headings
@@ -16,26 +17,31 @@ const typography = {
     ${fonts.primaryBold};
     ${fontSizes.size6};
     line-height: 1;
+    margin-bottom: ${spacerSizes.xlarge};
   `,
   headingXLarge: css`
     ${fonts.primaryBold};
     ${fontSizes.size5};
     line-height: 1;
+    margin-bottom: ${spacerSizes.medium};
   `,
   headingLarge: css`
     ${fonts.primaryBold};
     ${fontSizes.size4};
     line-height: 1.2;
+    margin-bottom: ${spacerSizes.medium};
   `,
   headingMedium: css`
     ${fonts.primaryRegular};
     ${fontSizes.size3};
     line-height: 1.2;
+    margin-bottom: ${spacerSizes.medium};
   `,
   headingSmall: css`
     ${fonts.primaryRegular};
     ${fontSizes.size2};
     line-height: 1.4;
+    margin-bottom: ${spacerSizes.small};
   `,
   headingXSmall: css`
     ${fonts.interfaceBold};
@@ -43,6 +49,7 @@ const typography = {
     letter-spacing: 1px;
     line-height: 1.2;
     text-transform: uppercase;
+    margin-bottom: ${spacerSizes.small};
   `,
   headingXXSmall: css`
     ${fonts.interfaceBold};
@@ -50,6 +57,7 @@ const typography = {
     letter-spacing: 1px;
     line-height: 1.2;
     text-transform: uppercase;
+    margin-bottom: ${spacerSizes.small};
   `,
 
   // Body
@@ -57,26 +65,31 @@ const typography = {
     ${fonts.bodyRegular};
     ${fontSizes.size2};
     line-height: 1.6;
+    margin-bottom: ${spacerSizes.xlarge};
   `,
   bodyItalic: css`
     ${fonts.bodyItalic};
     ${fontSizes.size2};
     line-height: 1.6;
+    margin-bottom: ${spacerSizes.xlarge};
   `,
   bodyBold: css`
     ${fonts.bodyBold};
     ${fontSizes.size2};
     line-height: 1.6;
+    margin-bottom: ${spacerSizes.xlarge};
   `,
   body: css`
     ${fonts.bodyRegular};
     ${fontSizes.size1};
     line-height: 1.6;
+    margin-bottom: ${spacerSizes.xlarge};
   `,
   finePrint: css`
     ${fonts.bodyRegular};
     ${fontSizes.size0};
     line-height: 1.6;
+    margin-bottom: ${spacerSizes.xlarge};
   `,
 };
 

--- a/src/base/typography/typographyVariables.js
+++ b/src/base/typography/typographyVariables.js
@@ -9,55 +9,64 @@ import { css } from 'styled-components';
 
 import fonts from './fonts';
 import fontSizes from './fontSizes';
-import spacerSizes from './../spacing';
+import spacerSizes from '../spacing';
 
-const typography = {
+// const bodyTypography
+
+// const headingTypography
+
+// const interfaceTypography
+
+
+
+
+const typographyVariables = {
+  // PageTitle
+  pageTitle: css`
+    font-family: HarrietDisplay;
+    font-size: 64px;
+    font-weight: bold;
+    line-height: 1;
+    letter-spacing: normal;
+  `,
+
   // Headings
   headingXXLarge: css`
     ${fonts.primaryBold};
     ${fontSizes.size6};
     line-height: 1;
-    margin-bottom: ${spacerSizes.xlarge};
   `,
   headingXLarge: css`
     ${fonts.primaryBold};
     ${fontSizes.size5};
     line-height: 1;
-    margin-bottom: ${spacerSizes.medium};
   `,
   headingLarge: css`
     ${fonts.primaryBold};
     ${fontSizes.size4};
     line-height: 1.2;
-    margin-bottom: ${spacerSizes.medium};
   `,
   headingMedium: css`
     ${fonts.primaryRegular};
     ${fontSizes.size3};
     line-height: 1.2;
-    margin-bottom: ${spacerSizes.medium};
   `,
   headingSmall: css`
     ${fonts.primaryRegular};
     ${fontSizes.size2};
     line-height: 1.4;
-    margin-bottom: ${spacerSizes.small};
   `,
   headingXSmall: css`
-    ${fonts.interfaceBold};
+    ${fonts.primaryLight};
     ${fontSizes.size1};
-    letter-spacing: 1px;
-    line-height: 1.2;
-    text-transform: uppercase;
-    margin-bottom: ${spacerSizes.small};
+    line-height: 1.4;
   `,
   headingXXSmall: css`
-    ${fonts.interfaceBold};
+    ${fonts.primaryLight};
     ${fontSizes.size0};
     letter-spacing: 1px;
     line-height: 1.2;
     text-transform: uppercase;
-    margin-bottom: ${spacerSizes.small};
   `,
 
   // Body
@@ -65,32 +74,27 @@ const typography = {
     ${fonts.bodyRegular};
     ${fontSizes.size2};
     line-height: 1.6;
-    margin-bottom: ${spacerSizes.xlarge};
   `,
   bodyItalic: css`
     ${fonts.bodyItalic};
     ${fontSizes.size2};
     line-height: 1.6;
-    margin-bottom: ${spacerSizes.xlarge};
   `,
   bodyBold: css`
     ${fonts.bodyBold};
     ${fontSizes.size2};
     line-height: 1.6;
-    margin-bottom: ${spacerSizes.xlarge};
   `,
   body: css`
     ${fonts.bodyRegular};
     ${fontSizes.size1};
     line-height: 1.6;
-    margin-bottom: ${spacerSizes.xlarge};
   `,
   finePrint: css`
     ${fonts.bodyRegular};
     ${fontSizes.size0};
     line-height: 1.6;
-    margin-bottom: ${spacerSizes.xlarge};
   `,
 };
 
-export default typography;
+export default typographyVariables;

--- a/src/components.js
+++ b/src/components.js
@@ -1,3 +1,6 @@
+// import css
+import './global.css';
+
 // Export main components
 export * from './components/input/Button';
 export * from './components/layout/Spacer';

--- a/src/components/typography/Heading/Heading.js
+++ b/src/components/typography/Heading/Heading.js
@@ -17,7 +17,7 @@ export const Heading = ({ children, color, level, size, ...others }) => {
 };
 
 export const HeadingColors = Object.keys(headingColors);
-export const HeadingLevels = [1, 2, 3, 4, 5, 6];
+export const HeadingLevels = [0, 1, 2, 3, 4, 5, 6];
 export const HeadingSizes = Object.keys(headingSizes);
 
 Heading.propTypes = {

--- a/src/components/typography/Heading/Heading.styles.js
+++ b/src/components/typography/Heading/Heading.styles.js
@@ -23,7 +23,6 @@ export const headingColors = {
 };
 
 const HeadingBase = styled.span`
-  margin: 0;
   color: ${p => headingColors[p.color]};
   ${p => headingSizes[p.size]};
 `;

--- a/src/components/typography/Heading/Heading.styles.js
+++ b/src/components/typography/Heading/Heading.styles.js
@@ -28,6 +28,7 @@ const HeadingBase = styled.span`
 `;
 
 export const headingElements = {
+  h0: HeadingBase.withComponent('p'),
   h1: HeadingBase.withComponent('h1'),
   h2: HeadingBase.withComponent('h2'),
   h3: HeadingBase.withComponent('h3'),

--- a/src/components/typography/Heading/Heading.styles.js
+++ b/src/components/typography/Heading/Heading.styles.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import typography from '../../../base/typography/typography';
+import typography from '../../../base/typography/typographyVariables';
 import { semanticColors, typographicColors } from '../../../base/color/colorVariables';
 
 export const headingSizes = {

--- a/src/components/typography/Paragraph/Paragraph.styles.js
+++ b/src/components/typography/Paragraph/Paragraph.styles.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import typography from '../../../base/typography/typography';
+import typography from '../../../base/typography/typographyVariables';
 import { semanticColors, typographicColors } from '../../../base/color/colorVariables';
 
 export const paragraphSizes = {

--- a/src/global.css
+++ b/src/global.css
@@ -1,5 +1,5 @@
 * {
-	margin: 0 0 4.8rem;
+	margin: 0 0 6.4rem;
 	line-height: 1.714285714;
 }
 

--- a/src/global.css
+++ b/src/global.css
@@ -1,0 +1,9 @@
+* {
+	margin: 0 0 4.8rem;
+	line-height: 1.714285714;
+}
+
+html {
+	font-size: 62.5%;
+	//background: purple;
+}

--- a/styleguide-ui/VariableTable.js
+++ b/styleguide-ui/VariableTable.js
@@ -1,0 +1,115 @@
+/* eslint-disable no-confusing-arrow */
+import PropTypes from 'prop-types';
+import React, { Fragment } from 'react';
+import styled from 'styled-components';
+
+import colors from '../src/base/color/colors';
+//import colorVariables from '../src/base/color/colorVariables';
+
+import fonts from '../src/base/typography/fonts';
+import fontSizes from '../src/base/typography/fontSizes';
+import typographyVariables from '../src/base/typography/typographyVariables';
+
+
+const StyledTable = styled.table`
+  border-bottom: 1px solid ${colors.gray30};
+  border-collapse: collapse;
+  color: ${colors.black};
+  font-family: monospace;
+  font-size: 13px;
+  width: 100%;
+
+  &:not(last-child) {
+    margin-bottom: 40px;
+  }
+`;
+
+const StyledRow = styled.tr`
+  &:nth-of-type(odd) {
+    background-color: ${colors.gray15};
+  }
+`;
+
+const StyledCell = styled.td`
+  border-top: 1px solid ${colors.gray30};
+  padding: 10px;
+
+  &:nth-of-type(even) {
+    letter-spacing: 1px;
+  }
+`;
+
+const StyledHeading = styled.h2`
+  font-weight: 400;
+  font-size: 2.1rem;
+  margin-bottom: 10px;
+`;
+
+const StyledCellColor = styled(StyledCell)`
+  background-color: ${p => p.color};
+  color: ${p => p.color === colors.black ? colors.white : colors.black};
+`;
+
+const StyledCellColorSpan = styled.span`
+  background-color: rgba(255, 255, 255, 0.3);
+  border-radius: 3px;
+  display: inline-block;
+  padding: 3px;
+`;
+
+const getMatchingVariableName = (colorValue, baseVariables) => {
+  const matchingValue = Object.entries(baseVariables).find(([, value]) => (
+    value === colorValue
+  ));
+
+  return matchingValue ? matchingValue[0] : null; // this is the name of the variable
+};
+
+export const VariableTable = ({ baseVariables, brandVariables }) => {
+  const renderVariableTables = Object.entries(brandVariables).map((category) => {
+    const [title, values] = category;
+
+    const renderCategoryValues = Object.entries(values).map((value) => {
+      const [name, colorValue] = value;
+
+      return (
+        <StyledRow key={name}>
+          <StyledCell>
+            {name}
+          </StyledCell>
+          <StyledCellColor color={colorValue} width="30%">
+            <StyledCellColorSpan>
+              {getMatchingVariableName(colorValue, baseVariables)}
+            </StyledCellColorSpan>
+          </StyledCellColor>
+        </StyledRow>
+      );
+    });
+
+    return (
+      <Fragment key={title}>
+        <StyledHeading>{title}</StyledHeading>
+        <StyledTable>
+          <tbody>
+            {renderCategoryValues}
+          </tbody>
+        </StyledTable>
+      </Fragment>
+    );
+  });
+
+  return (
+    <Fragment>
+      {renderVariableTables}
+    </Fragment>
+  );
+};
+
+// VariableTable.propTypes = {
+//   /** Type of variable table to output */
+//   variable: PropTypes.string,
+
+//   brandVariables: PropTypes.Object,
+// };
+
+export default VariableTable;

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -52,9 +52,9 @@ module.exports = {
           description: 'Nautilus provides a wide range of colours to use.',
         },
         {
-          name: 'Typography',
+          name: 'Typography Styles',
           content: 'docs/typography.md',
-          description: 'Typography samples and variations',
+          description: 'Nautilus provides a library of type styles to use.',
         },
         {
           name: 'Spacing',
@@ -90,7 +90,12 @@ module.exports = {
         {
           name: 'Colour Variables',
           content: 'docs/colorVariables.md',
-          description: 'Variables are used as design tokens.',
+          description: 'Colour variables are design tokens that can be overwritten by a brand in order to  theme the experience.',
+        },
+        {
+          name: 'Typography Variables',
+          content: 'docs/typographyVariables.md',
+          description: 'Typography variables are design tokens that can be overwritten by a brand in order to  theme the experience.',
         },
       ],
       sectionDepth: 3,

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -38,36 +38,62 @@ module.exports = {
       content: 'docs/introduction.md',
     },
     {
-      name: 'Colour Palette',
-      content: 'docs/colors.md',
-      description: 'Nautilus provides a wide range of colours to use.',
+      name: 'Foundation',
+      content: 'docs/foundation.md',
+      sections: [
+        {
+          name: 'Principles',
+          //content: 'docs/principles.md',
+          description: 'Overall principles to shape design decisions.',
+        },
+        {
+          name: 'Colour Palette',
+          content: 'docs/colors.md',
+          description: 'Nautilus provides a wide range of colours to use.',
+        },
+        {
+          name: 'Typography',
+          content: 'docs/typography.md',
+          description: 'Typography samples and variations',
+        },
+        {
+          name: 'Spacing',
+          content: 'docs/spacing.md',
+          description: 'Nautilus uses an 8pt spacing system. Get out your calculator.',
+        },
+      ],
+      sectionDepth: 2,
     },
     {
-      name: 'Colour Variables',
-      content: 'docs/colorVariables.md',
-      description: 'Variables are used as design tokens.',
+      name: 'Function',
+      content: 'docs/function.md',
+      sections: [
+        {
+          name: 'Input Components',
+          components: 'src/components/input/**/[A-Z]*.{js,jsx}',
+        },
+        {
+          name: 'Layout Components',
+          components: 'src/components/layout/**/[A-Z]*.{js,jsx}',
+        },
+        {
+          name: 'Typography Components',
+          components: 'src/components/typography/**/[A-Z]*.{js,jsx}',
+        },
+      ],
+      sectionDepth: 3,
     },
     {
-      name: 'Typography',
-      content: 'docs/typography.md',
-      description: 'Typography samples and variations',
-    },
-    {
-      name: 'Spacing',
-      content: 'docs/spacing.md',
-      description: 'Nautilus uses an 8pt spacing system. Get out your calculator.',
-    },
-    {
-      name: 'Input Components',
-      components: 'src/components/input/**/[A-Z]*.{js,jsx}',
-    },
-    {
-      name: 'Layout Components',
-      components: 'src/components/layout/**/[A-Z]*.{js,jsx}',
-    },
-    {
-      name: 'Typography Components',
-      components: 'src/components/typography/**/[A-Z]*.{js,jsx}',
+      name: 'Form',
+      content: 'docs/form.md',
+      sections: [
+        {
+          name: 'Colour Variables',
+          content: 'docs/colorVariables.md',
+          description: 'Variables are used as design tokens.',
+        },
+      ],
+      sectionDepth: 3,
     },
   ],
 };

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -23,10 +23,10 @@ module.exports = {
   styles: {
     StyleGuide: {
       '@global html': {
-        fontSize: '12px',
+        fontSize: '62.5%',
       },
       '@global body': {
-        fontSize: '1.4rem',
+        fontSize: '1.6rem',
       },
     },
   },


### PR DESCRIPTION
This is going to require a bit more work to get right, since it doesn't feel like it's totally working just yet.

Thinking to have Nautilus provide a "palette" of font variants (weight, size, family, variant, etc) that are then picked-and-chosen by the brand to form a functional/semantic palette, defined by usage.

- Heading (S, M, L) Used for primary headings throughout
- Subheading (M, L) Used for an additional, secondary heading
- Metadata (S, M) Used for small pieces of categorical data (date, tag). Often paired with a heading as an overline style.
- Body (S, M, L) Used for blocks of body text.
- Instruction (M, L) Used to communicate messages or instructions from the system to the user. (Label, Notice)
- Input (M, L) Used when the user inputs messages to the system. (Text field, button)

That may actually turn out  to be more variants than strictly needed, so we may want to tune it down a bit more still. 

Overwriting would be sequential, meaning something like this:

fontSize1: 16px;
fontSize2: 21px;
fontSize3: 48px;
==============

And then brand would apply like so:

bodyFont: Harriet Text;
headingFont: Harriet Display;
interfaceFont: SF UI;

Fin-tuning as needed by overwriting specific components.


