### PR TITLE
Feat: add page title

### DIFF
--- a/src/components/PageTitle/README.md
+++ b/src/components/PageTitle/README.md
@@ -1,0 +1,43 @@
+A Page Title is a piece of text that describes the current page or screen's content.
+
+You can think of `<PageTitle>` as a combination `<title>` and `<h1>` tag; it is used to describe the content of the entire page/screen available to the user, and should not change unless the user navigates away from the current view. **Every page you create should have one and only one `<PageTitle>` component.**
+
+```jsx
+<PageTitle>My Homepage</PageTitle>
+```
+
+## Usage
+
+Use a `<PageTitle>` to introduce the user to the entirety of the content available in the current view. On a blog, for instance, your index view might use: `<PageTitle>My Posts</PageTitle>` and an individual post would use its post title: `<PageTitle>{post.title}</PageTitle>`.
+
+<!-- TODO for @tofumatt: implement this feature. -->
+When using `<DocumentTitle>`, which uses `react-helmet`, the content inside `<PageTitle>` will be inserted into your page's `<title>` tag. If your `<PageTitle>` contains a link or other content aside from plain text, you should use the `documentTitle` prop to set the content that will be used by `<DocumentTitle>`:
+
+```jsx inside Markdown
+const title = 'This title is linked';
+<PageTitle documentTitle={title}>
+  <a href="/#/🛠 Function/Components/PageTitle">{title}</a>
+</PageTitle>
+```
+
+Don't use a `<PageTitle>` for:
+- Text describing only part of a page's content. Use `<Heading>` instead.
+- Creating multiple `<h1>` components. There should only be one `<PageTitle>` on the page.
+
+## Appearance
+
+- TODO for @sarahmonster.
+
+## Variations
+
+TODO for @sarahmonster.
+
+## Voice & Tone
+
+A page title should ideally be very short and describe the content available to the user on the page. If the page is for editorial content (eg. a blog post or other piece of prose), the title of said prose is appropriate (even if it's long). If the page is for an app, something short and descriptive like `<PageTitle>Manage Account</PageTitle>` is appropriate. Avoiding describing nested content or actions; `<PageTitle>Manage Account: Update your Credit Card Information and Change your Email</PageTitle>` would be better split into separate `<Heading>` sections for each action.
+
+## Accessibility
+
+For accessibility reasons, it's important that `<PageTitle>` exists to describe the purpose of the page to a user of assistive technology. It's also useful for search engine crawlers.
+
+- Always use a single `<PageTitle>` tag per page.

--- a/src/components/PageTitle/README.md
+++ b/src/components/PageTitle/README.md
@@ -1,43 +1,50 @@
-A Page Title is a piece of text that describes the current page or screen's content.
-
-You can think of `<PageTitle>` as a combination `<title>` and `<h1>` tag; it is used to describe the content of the entire page/screen available to the user, and should not change unless the user navigates away from the current view. **Every page you create should have one and only one `<PageTitle>` component.**
+A Page Title is a short line of text that describes the current page or screen. Every page or screen in your site or app should have **one** `<PageTitle>` component: no more, no less.
 
 ```jsx
-<PageTitle>My Homepage</PageTitle>
+<PageTitle>Super-groovy fantastico homepage!</PageTitle>
 ```
 
 ## Usage
 
-Use a `<PageTitle>` to introduce the user to the entirety of the content available in the current view. On a blog, for instance, your index view might use: `<PageTitle>My Posts</PageTitle>` and an individual post would use its post title: `<PageTitle>{post.title}</PageTitle>`.
-
-<!-- TODO for @tofumatt: implement this feature. -->
-When using `<DocumentTitle>`, which uses `react-helmet`, the content inside `<PageTitle>` will be inserted into your page's `<title>` tag. If your `<PageTitle>` contains a link or other content aside from plain text, you should use the `documentTitle` prop to set the content that will be used by `<DocumentTitle>`:
-
-```jsx inside Markdown
-const title = 'This title is linked';
-<PageTitle documentTitle={title}>
-  <a href="/#/🛠 Function/Components/PageTitle">{title}</a>
-</PageTitle>
-```
+Use a `<PageTitle>` to provide a visual indication and summary of the current page or screen.
 
 Don't use a `<PageTitle>` for:
-- Text describing only part of a page's content. Use `<Heading>` instead.
+- Text describing only a portion of a page's content. Use `<Heading>` instead.
 - Creating multiple `<h1>` components. There should only be one `<PageTitle>` on the page.
+
+## Technical Implementation
+
+You can think of `<PageTitle>` as a combination `<title>` and `<h1>` tag. It is used to describe the content of the entire page/screen available to the user, and should not change unless the user navigates away from the current view. **Every page you create** should have **one and only one** `<PageTitle>` component.
+
+Use a `<PageTitle>` to introduce the user to the entirety of the content available in the current view. On a blog, for instance, your index view might use: `<PageTitle>My Posts</PageTitle>` and an individual post would use its post title: `<PageTitle>{post.title}</PageTitle>`.
+
+ When using `<DocumentTitle>`, which uses `react-helmet`, the content inside `<PageTitle>` will be inserted into your page's `<title>` tag. If your `<PageTitle>` contains a link or other content aside from plain text, you should use the `documentTitle` prop to set the content that will be used by `<DocumentTitle>`:
+
+ ```jsx inside Markdown
+ const title = 'This title is linked';
+ <PageTitle documentTitle={title}>
+   <a href="/#/🛠 Function/Components/PageTitle">{title}</a>
+ </PageTitle>
+ ```
 
 ## Appearance
 
-- TODO for @sarahmonster.
-
-## Variations
-
-TODO for @sarahmonster.
+- Use a consistent style rules for `<PageTitle>`s across your site, even if you're doing creative art direction.
+- Since a `<PageTitle>` is highest in hierarchy, it should be larger or have more emphasis than other `<Heading>`s.
+- `<PageTitle>`s can use styling similar to `<Heading>`s, but doesn't need to. Since they are the highest in the hierarchy and only appear once per view, you can feel free to get a little creative with them. Highlight your brand, apply funky styles like gradients or skews, use hand-lettering effects, or art-direct each one with different typography and special styling.
 
 ## Voice & Tone
 
-A page title should ideally be very short and describe the content available to the user on the page. If the page is for editorial content (eg. a blog post or other piece of prose), the title of said prose is appropriate (even if it's long). If the page is for an app, something short and descriptive like `<PageTitle>Manage Account</PageTitle>` is appropriate. Avoiding describing nested content or actions; `<PageTitle>Manage Account: Update your Credit Card Information and Change your Email</PageTitle>` would be better split into separate `<Heading>` sections for each action.
+- Keep the title short and descriptive of the page's content.
+- `<PageTitle>` can use Sentence case or Title Case, depending on your personal tastes and the formality of your site or app. Whichever you pick, be consistent throughout!
+- If the page is for editorial content (eg. a blog post or other piece of prose), the title of said prose is appropriate (even if it's long).
+- If the page is for an app, something short and descriptive like `Manage Account` is appropriate.
+- Avoiding describing nested content or actions. `Manage Account: Update your Credit Card Information and Change your Email` would be better split into separate `<Heading>` sections for each action.
 
 ## Accessibility
 
 For accessibility reasons, it's important that `<PageTitle>` exists to describe the purpose of the page to a user of assistive technology. It's also useful for search engine crawlers.
 
-- Always use a single `<PageTitle>` tag per page.
+- Every page or screen in your site or app should have **one** `<PageTitle>` component.
+- Don't use more than **one** `<PageTitle>` component on a single page or screen.
+- Your `<PageTitle>` should *only* be the title of your site on your homepage. On all other pages, the `<PageTitle>` should describe the content of that page.

--- a/src/components/PageTitle/__snapshots__/index.test.js.snap
+++ b/src/components/PageTitle/__snapshots__/index.test.js.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PageTitle should output pageTitle CSS 1`] = `
+.emotion-0 {
+  font-family: -apple-system,BlinkMacSystemFont,San Francisco,Roboto,Segoe UI,Helvetica Neue,sans-serif;
+  font-weight: 700;
+  font-size: 6.9rem;
+  line-height: 1.0434782608695652;
+}
+
+<h1
+  class="emotion-0 emotion-1"
+>
+  My Blog Posts
+</h1>
+`;

--- a/src/components/PageTitle/index.js
+++ b/src/components/PageTitle/index.js
@@ -1,0 +1,30 @@
+import { css } from '@emotion/core';
+import styled from '@emotion/styled';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { pageTitle } from 'themes/mixins';
+
+export const PageTitle = ({ children, documentTitle, ...otherProps }) => {
+  // const documentTitleToUse = documentTitle || children;
+
+  return <h1 {...otherProps}>{children}</h1>;
+};
+
+PageTitle.defaultProps = {
+  children: undefined,
+  documentTitle: undefined,
+};
+
+PageTitle.propTypes = {
+  /** @ignore */
+  children: PropTypes.node,
+  /** String to pass to the `<DocumentTitle />` tag if the children of your `<PageTitle />` are more than just text content. */
+  documentTitle: PropTypes.string,
+};
+
+export default styled(PageTitle)(({ theme }) => {
+  return css`
+    ${pageTitle(theme)}
+  `;
+});

--- a/src/components/PageTitle/index.test.js
+++ b/src/components/PageTitle/index.test.js
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import { render } from 'utils/testing';
+
+import PageTitle from '.';
+
+describe('PageTitle', () => {
+  it('should render an <h1>', () => {
+    const { container } = render(<PageTitle>My Account</PageTitle>);
+
+    expect(container.firstChild.tagName).toEqual('H1');
+  });
+
+  it('should output its children', () => {
+    const { getByTestId } = render(
+      <PageTitle>
+        <div data-testid="child" />
+      </PageTitle>,
+    );
+
+    expect(getByTestId('child')).toBeDefined();
+  });
+
+  it('should output pageTitle CSS', () => {
+    const { container } = render(<PageTitle>My Blog Posts</PageTitle>);
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/styleguide/docs/components.md
+++ b/styleguide/docs/components.md
@@ -8,7 +8,7 @@ const components = Object.keys(loadComponents).map((name) => {
 
 	return (
 		<li key={name}>
-			<a href={`#/Function/Components/${normalisedName}`}>
+			<a href={`#/🛠%20Function/Components/${normalisedName}`}>
 				<code>&lt;{normalisedName} /&gt;</code>
 			</a>
 		</li>


### PR DESCRIPTION
Closes #49.

This doesn't _use_ `PageTitle` anywhere on our site yet but I'd like to integrate it into things after I get it merged and tweak the markdown output further in a separate PR. I think doing that after we have lists is best, because then I'll be able to use a lot of our base components for the style guide.