### PR TITLE
Add List component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7794,6 +7794,11 @@
       "dev": true,
       "optional": true
     },
+    "nanoid": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.0.3.tgz",
+      "integrity": "sha512-NbaoqdhIYmY6FXDRB4eYtDVC9Z9eCbn8TyaiC16LNKtpPv/aqa0tOPD8y6gNE4yUNnaZ7LLhYtXOev/6+cBtfw=="
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -9989,6 +9994,14 @@
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true
+    },
+    "shortid": {
+      "version": "2.2.14",
+      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.14.tgz",
+      "integrity": "sha512-4UnZgr9gDdA1kaKj/38IiudfC3KHKhDc1zi/HSxd9FQDR0VLwH3/y79tZJLsVYPsJgIjeHjqIWaWVRJUj9qZOQ==",
+      "requires": {
+        "nanoid": "^2.0.0"
+      }
     },
     "shx": {
       "version": "0.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1833,6 +1833,12 @@
       "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
       "dev": true
     },
+    "array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true
+    },
     "array-flatten": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
@@ -1880,6 +1886,12 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
     "asn1": {
@@ -1991,6 +2003,20 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
+    },
+    "autoprefixer": {
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.5.1.tgz",
+      "integrity": "sha512-KJSzkStUl3wP0D5sdMlP82Q52JLy5+atf2MHAre48+ckWkXgixmfHyWmA77wFDy6jTHU6mIgXv6hAQ2mf1PjJQ==",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.5.4",
+        "caniuse-lite": "^1.0.30000957",
+        "normalize-range": "^0.1.2",
+        "num2fraction": "^1.2.2",
+        "postcss": "^7.0.14",
+        "postcss-value-parser": "^3.3.1"
+      }
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -2588,6 +2614,25 @@
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
     },
+    "camelcase-keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+      "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+      "dev": true,
+      "requires": {
+        "camelcase": "^4.1.0",
+        "map-obj": "^2.0.0",
+        "quick-lru": "^1.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        }
+      }
+    },
     "caniuse-lite": {
       "version": "1.0.30000969",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000969.tgz",
@@ -2811,6 +2856,16 @@
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
       "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
       "dev": true
+    },
+    "clone-regexp": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-1.0.1.tgz",
+      "integrity": "sha512-Fcij9IwRW27XedRIJnSOEupS7RVcXtObJXbcUOX93UCLqqOdRpkvzKywOOSizmEK/Is3S/RHX9dLdfo6R1Q1mw==",
+      "dev": true,
+      "requires": {
+        "is-regexp": "^1.0.0",
+        "is-supported-regexp-flag": "^1.0.0"
+      }
     },
     "clsx": {
       "version": "1.0.4",
@@ -3315,6 +3370,15 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.4.tgz",
       "integrity": "sha512-lAJUJP3M6HxFXbqtGRc0iZrdyeN+WzOWeY0q/VnFzI+kqVrYIzC7bWlKqCW7oCIdzoPkvfp82EVvrTlQ8zsWQg=="
     },
+    "currently-unhandled": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+      "dev": true,
+      "requires": {
+        "array-find-index": "^1.0.1"
+      }
+    },
     "cyclist": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
@@ -3380,6 +3444,24 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
+    },
+    "decamelize-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+      "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+      "dev": true,
+      "requires": {
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
+      },
+      "dependencies": {
+        "map-obj": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+          "dev": true
+        }
+      }
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -3646,10 +3728,26 @@
         "esutils": "^2.0.2"
       }
     },
+    "dom-serializer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+      "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "^1.3.0",
+        "entities": "^1.1.1"
+      }
+    },
     "domain-browser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
       "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
+      "dev": true
+    },
+    "domelementtype": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
       "dev": true
     },
     "domexception": {
@@ -3659,6 +3757,34 @@
       "dev": true,
       "requires": {
         "webidl-conversions": "^4.0.2"
+      }
+    },
+    "domhandler": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1"
+      }
+    },
+    "domutils": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+      "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+      "dev": true,
+      "requires": {
+        "dom-serializer": "0",
+        "domelementtype": "1"
+      }
+    },
+    "dot-prop": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+      "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+      "dev": true,
+      "requires": {
+        "is-obj": "^1.0.0"
       }
     },
     "duplexer": {
@@ -3763,6 +3889,12 @@
         "memory-fs": "^0.4.0",
         "tapable": "^1.0.0"
       }
+    },
+    "entities": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+      "dev": true
     },
     "errno": {
       "version": "0.1.7",
@@ -4358,6 +4490,15 @@
         "strip-eof": "^1.0.0"
       }
     },
+    "execall": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execall/-/execall-1.0.0.tgz",
+      "integrity": "sha1-c9CQTjlbPKsGWLCNCewlMH8pu3M=",
+      "dev": true,
+      "requires": {
+        "clone-regexp": "^1.0.0"
+      }
+    },
     "exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
@@ -4946,7 +5087,8 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4970,13 +5112,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4993,19 +5137,22 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5136,7 +5283,8 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5150,6 +5298,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5166,6 +5315,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5174,13 +5324,15 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5201,6 +5353,7 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5289,7 +5442,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5303,6 +5457,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5398,7 +5553,8 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5440,6 +5596,7 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5461,6 +5618,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5509,13 +5667,15 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -5692,6 +5852,12 @@
         }
       }
     },
+    "globjoin": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
+      "integrity": "sha1-L0SUrIkZ43Z8XLtpHp9GMyQoXUM=",
+      "dev": true
+    },
     "glogg": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.2.tgz",
@@ -5699,6 +5865,23 @@
       "dev": true,
       "requires": {
         "sparkles": "^1.0.0"
+      }
+    },
+    "gonzales-pe": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-4.2.4.tgz",
+      "integrity": "sha512-v0Ts/8IsSbh9n1OJRnSfa7Nlxi4AkXIsWB6vPept8FDbL4bXn3FNuxjYtO/nmBGu7GDkL9MFeGebeSu6l55EPQ==",
+      "dev": true,
+      "requires": {
+        "minimist": "1.1.x"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
+          "integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=",
+          "dev": true
+        }
       }
     },
     "good-listener": {
@@ -5917,6 +6100,39 @@
       "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8=",
       "dev": true
     },
+    "html-tags": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-2.0.0.tgz",
+      "integrity": "sha1-ELMKOGCF9Dzt41PMj6fLDe7qZos=",
+      "dev": true
+    },
+    "htmlparser2": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "^1.3.1",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^3.1.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
     "http-deceiver": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
@@ -6030,6 +6246,12 @@
         "resolve-from": "^3.0.0"
       }
     },
+    "import-lazy": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-3.1.0.tgz",
+      "integrity": "sha512-8/gvXvX2JMn0F+CDlSC4l6kOmVaLOO3XLkksI7CI3Ud95KDYJuYur2b9P/PUt/i/pDAMd/DulQsNbbbmRRsDIQ==",
+      "dev": true
+    },
     "import-local": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
@@ -6044,6 +6266,18 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "indent-string": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+      "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+      "dev": true
+    },
+    "indexes-of": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+      "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
       "dev": true
     },
     "indexof": {
@@ -6431,6 +6665,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
+    "is-supported-regexp-flag": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.1.tgz",
+      "integrity": "sha512-3vcJecUUrpgCqc/ca0aWeNu64UGgxcvO60K/Fkr1N6RSvfGCTU60UKN68JDmKokgba0rFFJs12EnzOQa14ubKQ==",
       "dev": true
     },
     "is-symbol": {
@@ -7269,6 +7509,12 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
     },
+    "known-css-properties": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.13.0.tgz",
+      "integrity": "sha512-6VWDxNr7cQXPDtMdCWLZMK3E8hdLrpyPPRdx6RbyvqklqgM6/XNFsVopv8QOZ+hRB6iHG/urEDwzlWbmMCv/kw==",
+      "dev": true
+    },
     "lcid": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
@@ -7413,6 +7659,16 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
+    "loud-rejection": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+      "dev": true,
+      "requires": {
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
+      }
+    },
     "lowercase-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
@@ -7478,6 +7734,12 @@
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
       "dev": true
     },
+    "map-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+      "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+      "dev": true
+    },
     "map-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -7508,6 +7770,12 @@
         "prop-types": "^15.6.2",
         "unquote": "^1.1.0"
       }
+    },
+    "mathml-tag-names": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.1.tgz",
+      "integrity": "sha512-pWB896KPGSGkp1XtyzRBftpTzwSOL0Gfk0wLvxt4f2mgzjY19o0LxJ3U25vNWTzsh7da+KTbuXQoQ3lOJZ8WHw==",
+      "dev": true
     },
     "md5.js": {
       "version": "1.3.5",
@@ -7562,6 +7830,122 @@
       "requires": {
         "errno": "^0.1.3",
         "readable-stream": "^2.0.1"
+      }
+    },
+    "meow": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
+      "integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
+      "dev": true,
+      "requires": {
+        "camelcase-keys": "^4.0.0",
+        "decamelize-keys": "^1.0.0",
+        "loud-rejection": "^1.0.0",
+        "minimist-options": "^3.0.1",
+        "normalize-package-data": "^2.3.4",
+        "read-pkg-up": "^3.0.0",
+        "redent": "^2.0.0",
+        "trim-newlines": "^2.0.0",
+        "yargs-parser": "^10.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+          "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+          "dev": true,
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^3.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+          "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0"
+          }
+        }
       }
     },
     "merge-descriptors": {
@@ -7682,6 +8066,16 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+    },
+    "minimist-options": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
+      "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
+      "dev": true,
+      "requires": {
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0"
+      }
     },
     "mississippi": {
       "version": "2.0.0",
@@ -7948,6 +8342,18 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
     },
+    "normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
+      "dev": true
+    },
+    "normalize-selector": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/normalize-selector/-/normalize-selector-0.2.0.tgz",
+      "integrity": "sha1-0LFF62kRicY6eNIB3E/bEpPvDAM=",
+      "dev": true
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -7956,6 +8362,12 @@
       "requires": {
         "path-key": "^2.0.0"
       }
+    },
+    "num2fraction": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+      "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
+      "dev": true
     },
     "number-is-nan": {
       "version": "1.0.1",
@@ -8458,6 +8870,12 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
+    "picomatch": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.0.7.tgz",
+      "integrity": "sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==",
+      "dev": true
+    },
     "pify": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
@@ -8595,6 +9013,156 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true
+    },
+    "postcss": {
+      "version": "7.0.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+      "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2",
+        "source-map": "^0.6.1",
+        "supports-color": "^6.1.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "postcss-html": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/postcss-html/-/postcss-html-0.36.0.tgz",
+      "integrity": "sha512-HeiOxGcuwID0AFsNAL0ox3mW6MHH5cstWN1Z3Y+n6H+g12ih7LHdYxWwEA/QmrebctLjo79xz9ouK3MroHwOJw==",
+      "dev": true,
+      "requires": {
+        "htmlparser2": "^3.10.0"
+      }
+    },
+    "postcss-jsx": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/postcss-jsx/-/postcss-jsx-0.36.0.tgz",
+      "integrity": "sha512-/lWOSXSX5jlITCKFkuYU2WLFdrncZmjSVyNpHAunEgirZXLwI8RjU556e3Uz4mv0WVHnJA9d3JWb36lK9Yx99g==",
+      "dev": true,
+      "requires": {
+        "@babel/core": ">=7.1.0"
+      }
+    },
+    "postcss-less": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-3.1.4.tgz",
+      "integrity": "sha512-7TvleQWNM2QLcHqvudt3VYjULVB49uiW6XzEUFmvwHzvsOEF5MwBrIXZDJQvJNFGjJQTzSzZnDoCJ8h/ljyGXA==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.14"
+      }
+    },
+    "postcss-markdown": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/postcss-markdown/-/postcss-markdown-0.36.0.tgz",
+      "integrity": "sha512-rl7fs1r/LNSB2bWRhyZ+lM/0bwKv9fhl38/06gF6mKMo/NPnp55+K1dSTosSVjFZc0e1ppBlu+WT91ba0PMBfQ==",
+      "dev": true,
+      "requires": {
+        "remark": "^10.0.1",
+        "unist-util-find-all-after": "^1.0.2"
+      }
+    },
+    "postcss-media-query-parser": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
+      "integrity": "sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ=",
+      "dev": true
+    },
+    "postcss-reporter": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-6.0.1.tgz",
+      "integrity": "sha512-LpmQjfRWyabc+fRygxZjpRxfhRf9u/fdlKf4VHG4TSPbV2XNsuISzYW1KL+1aQzx53CAppa1bKG4APIB/DOXXw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.1",
+        "lodash": "^4.17.11",
+        "log-symbols": "^2.2.0",
+        "postcss": "^7.0.7"
+      }
+    },
+    "postcss-resolve-nested-selector": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz",
+      "integrity": "sha1-Kcy8fDfe36wwTp//C/FZaz9qDk4=",
+      "dev": true
+    },
+    "postcss-safe-parser": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-4.0.1.tgz",
+      "integrity": "sha512-xZsFA3uX8MO3yAda03QrG3/Eg1LN3EPfjjf07vke/46HERLZyHrTsQ9E1r1w1W//fWEhtYNndo2hQplN2cVpCQ==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.0"
+      }
+    },
+    "postcss-sass": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/postcss-sass/-/postcss-sass-0.3.5.tgz",
+      "integrity": "sha512-B5z2Kob4xBxFjcufFnhQ2HqJQ2y/Zs/ic5EZbCywCkxKd756Q40cIQ/veRDwSrw1BF6+4wUgmpm0sBASqVi65A==",
+      "dev": true,
+      "requires": {
+        "gonzales-pe": "^4.2.3",
+        "postcss": "^7.0.1"
+      }
+    },
+    "postcss-scss": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-2.0.0.tgz",
+      "integrity": "sha512-um9zdGKaDZirMm+kZFKKVsnKPF7zF7qBAtIfTSnZXD1jZ0JNZIxdB6TxQOjCnlSzLRInVl2v3YdBh/M881C4ug==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.0"
+      }
+    },
+    "postcss-selector-parser": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
+      "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+      "dev": true,
+      "requires": {
+        "dot-prop": "^4.1.1",
+        "indexes-of": "^1.0.1",
+        "uniq": "^1.0.1"
+      }
+    },
+    "postcss-sorting": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-sorting/-/postcss-sorting-5.0.0.tgz",
+      "integrity": "sha512-m25mKLNq0fPAyZFElQ1hngRDFQDMlc+9ZwoWsL8oix6i1GsBzIxyke6sDeY9BXee7L86z4tex01fcH/9wTj3Jg==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.11",
+        "postcss": "^7.0.14"
+      }
+    },
+    "postcss-syntax": {
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/postcss-syntax/-/postcss-syntax-0.36.2.tgz",
+      "integrity": "sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==",
+      "dev": true
+    },
+    "postcss-value-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
       "dev": true
     },
     "prelude-ls": {
@@ -8797,6 +9365,12 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
       "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==",
+      "dev": true
+    },
+    "quick-lru": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
+      "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
       "dev": true
     },
     "randombytes": {
@@ -9330,6 +9904,16 @@
       "dev": true,
       "requires": {
         "minimatch": "3.0.4"
+      }
+    },
+    "redent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+      "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+      "dev": true,
+      "requires": {
+        "indent-string": "^3.0.0",
+        "strip-indent": "^2.0.0"
       }
     },
     "regenerate": {
@@ -10348,6 +10932,12 @@
         }
       }
     },
+    "specificity": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/specificity/-/specificity-0.4.1.tgz",
+      "integrity": "sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==",
+      "dev": true
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -10585,11 +11175,333 @@
       "integrity": "sha1-Cuff8DAKYHWkwpP7YRG0yx0Mt7c=",
       "dev": true
     },
+    "strip-indent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+      "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+      "dev": true
+    },
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
+    },
+    "style-search": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
+      "integrity": "sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI=",
+      "dev": true
+    },
+    "stylelint": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-10.0.1.tgz",
+      "integrity": "sha512-NbpD9BvQRmPe7QfaLB2OqhhDr5g6SAn43AAH2XLyqtQ9ZcioQECgadkIbormfhzxLhccAQWBZbVNiZz1oqEf8g==",
+      "dev": true,
+      "requires": {
+        "autoprefixer": "^9.5.1",
+        "balanced-match": "^1.0.0",
+        "chalk": "^2.4.2",
+        "cosmiconfig": "^5.2.0",
+        "debug": "^4.1.1",
+        "execall": "^1.0.0",
+        "file-entry-cache": "^5.0.1",
+        "get-stdin": "^7.0.0",
+        "global-modules": "^2.0.0",
+        "globby": "^9.2.0",
+        "globjoin": "^0.1.4",
+        "html-tags": "^2.0.0",
+        "ignore": "^5.0.6",
+        "import-lazy": "^3.1.0",
+        "imurmurhash": "^0.1.4",
+        "known-css-properties": "^0.13.0",
+        "leven": "^3.1.0",
+        "lodash": "^4.17.11",
+        "log-symbols": "^2.2.0",
+        "mathml-tag-names": "^2.1.0",
+        "meow": "^5.0.0",
+        "micromatch": "^4.0.0",
+        "normalize-selector": "^0.2.0",
+        "pify": "^4.0.1",
+        "postcss": "^7.0.14",
+        "postcss-html": "^0.36.0",
+        "postcss-jsx": "^0.36.0",
+        "postcss-less": "^3.1.4",
+        "postcss-markdown": "^0.36.0",
+        "postcss-media-query-parser": "^0.2.3",
+        "postcss-reporter": "^6.0.1",
+        "postcss-resolve-nested-selector": "^0.1.1",
+        "postcss-safe-parser": "^4.0.1",
+        "postcss-sass": "^0.3.5",
+        "postcss-scss": "^2.0.0",
+        "postcss-selector-parser": "^3.1.0",
+        "postcss-syntax": "^0.36.2",
+        "postcss-value-parser": "^3.3.1",
+        "resolve-from": "^5.0.0",
+        "signal-exit": "^3.0.2",
+        "slash": "^2.0.0",
+        "specificity": "^0.4.1",
+        "string-width": "^4.1.0",
+        "style-search": "^0.1.0",
+        "sugarss": "^2.0.0",
+        "svg-tags": "^1.0.0",
+        "table": "^5.2.3"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "get-stdin": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
+          "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
+          "dev": true
+        },
+        "global-modules": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+          "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
+          "dev": true,
+          "requires": {
+            "global-prefix": "^3.0.0"
+          }
+        },
+        "global-prefix": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+          "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+          "dev": true,
+          "requires": {
+            "ini": "^1.3.5",
+            "kind-of": "^6.0.2",
+            "which": "^1.3.1"
+          }
+        },
+        "globby": {
+          "version": "9.2.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-9.2.0.tgz",
+          "integrity": "sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==",
+          "dev": true,
+          "requires": {
+            "@types/glob": "^7.1.1",
+            "array-union": "^1.0.2",
+            "dir-glob": "^2.2.2",
+            "fast-glob": "^2.2.6",
+            "glob": "^7.1.3",
+            "ignore": "^4.0.3",
+            "pify": "^4.0.1",
+            "slash": "^2.0.0"
+          },
+          "dependencies": {
+            "ignore": {
+              "version": "4.0.6",
+              "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+              "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+              "dev": true
+            }
+          }
+        },
+        "ignore": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.2.tgz",
+          "integrity": "sha512-vdqWBp7MyzdmHkkRWV5nY+PfGRbYbahfuvsBCh277tq+w9zyNi7h5CYJCK0kmzti9kU+O/cB7sE8HvKv6aXAKQ==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "leven": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+          "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        },
+        "slash": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+          "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.1.0.tgz",
+          "integrity": "sha512-NrX+1dVVh+6Y9dnQ19pR0pP4FiEIlUvdTGn8pw6CKTNq5sgib2nIhmUNT5TAmhWmvKr3WcxBcP3E8nWezuipuQ==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^5.2.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
+      }
+    },
+    "stylelint-config-prettier": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-prettier/-/stylelint-config-prettier-5.2.0.tgz",
+      "integrity": "sha512-ehrG/mBi9CTKkOBi0wlStX58+g9eGJhJW/jFEcCm/dUVHg9I2+T90k4tlyratvhlz876dyrTlor7gvDEaohVnA==",
+      "dev": true
+    },
+    "stylelint-config-recommended": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-2.2.0.tgz",
+      "integrity": "sha512-bZ+d4RiNEfmoR74KZtCKmsABdBJr4iXRiCso+6LtMJPw5rd/KnxUWTxht7TbafrTJK1YRjNgnN0iVZaJfc3xJA==",
+      "dev": true
+    },
+    "stylelint-config-standard": {
+      "version": "18.3.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-18.3.0.tgz",
+      "integrity": "sha512-Tdc/TFeddjjy64LvjPau9SsfVRexmTFqUhnMBrzz07J4p2dVQtmpncRF/o8yZn8ugA3Ut43E6o1GtjX80TFytw==",
+      "dev": true,
+      "requires": {
+        "stylelint-config-recommended": "^2.2.0"
+      }
+    },
+    "stylelint-config-styled-components": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/stylelint-config-styled-components/-/stylelint-config-styled-components-0.1.1.tgz",
+      "integrity": "sha512-z5Xz/9GmvxO6e/DLzBMwkB85zHxEEjN6K7Cj80Bi+o/9vR9eS3GX3E9VuMnX9WLFYulqbqLtTapGGY28JBiy9Q==",
+      "dev": true
+    },
+    "stylelint-order": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-order/-/stylelint-order-3.0.0.tgz",
+      "integrity": "sha512-CaK3ebU5qSDY4aQZ5yA5uCL1jjAeK+TQeyKcH1w1O/wxC1GjM6JCv0msrA3Wno29F1jW/1UoWIsRFeo7hk9gtg==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.11",
+        "postcss": "^7.0.14",
+        "postcss-sorting": "^5.0.0"
+      }
+    },
+    "stylelint-prettier": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stylelint-prettier/-/stylelint-prettier-1.1.1.tgz",
+      "integrity": "sha512-H7Zjb+9ufF0dTjjJ4qSbN/yeAV14BNUK5rl267lvYfmmW4Swlz4a2rfwqqgiN/YlntHXXzM6Nh/UXHFIvLI8zA==",
+      "dev": true,
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
+      }
+    },
+    "stylelint-processor-styled-components": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/stylelint-processor-styled-components/-/stylelint-processor-styled-components-1.8.0.tgz",
+      "integrity": "sha512-sADydhLPwtR9YJBydlO6X209sjT3rG9nr7sn/cEFZtoeZF3tI60HtxIOFC12vVVMvpKFS+E0smMiKA6FcVZO9A==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.0.0",
+        "@babel/traverse": "^7.0.0",
+        "micromatch": "^4.0.2",
+        "postcss": "^7.0.0"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
+      }
+    },
+    "sugarss": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/sugarss/-/sugarss-2.0.0.tgz",
+      "integrity": "sha512-WfxjozUk0UVA4jm+U1d736AUpzSrNsQcIbyOkoE364GrtWmIrFdk5lksEupgWMD4VaT/0kVx1dobpiDumSgmJQ==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.2"
+      }
     },
     "supports-color": {
       "version": "5.5.0",
@@ -10599,6 +11511,12 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
+    },
+    "svg-tags": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
+      "integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=",
+      "dev": true
     },
     "symbol-observable": {
       "version": "1.2.0",
@@ -11005,6 +11923,12 @@
       "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
       "dev": true
     },
+    "trim-newlines": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+      "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
+      "dev": true
+    },
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
@@ -11197,6 +12121,12 @@
         }
       }
     },
+    "uniq": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
+      "dev": true
+    },
     "unique-filename": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
@@ -11213,6 +12143,23 @@
       "dev": true,
       "requires": {
         "imurmurhash": "^0.1.4"
+      }
+    },
+    "unist-util-find-all-after": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unist-util-find-all-after/-/unist-util-find-all-after-1.0.4.tgz",
+      "integrity": "sha512-CaxvMjTd+yF93BKLJvZnEfqdM7fgEACsIpQqz8vIj9CJnUb9VpyymFS3tg6TCtgrF7vfCJBF5jbT2Ox9CBRYRQ==",
+      "dev": true,
+      "requires": {
+        "unist-util-is": "^3.0.0"
+      },
+      "dependencies": {
+        "unist-util-is": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
+          "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==",
+          "dev": true
+        }
       }
     },
     "unist-util-is": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
+    "shortid": "^2.2.14",
     "shx": "^0.3.2"
   },
   "devDependencies": {

--- a/src/components/List/Heading.js
+++ b/src/components/List/Heading.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export const ListHeading = (props) => {
+  return <React.Fragment {...props} />;
+};
+
+export default ListHeading;

--- a/src/components/List/Item.js
+++ b/src/components/List/Item.js
@@ -1,3 +1,4 @@
+import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -15,6 +16,15 @@ ListItem.propTypes = {
   children: PropTypes.node,
 };
 
-const StyledListItem = styled(ListItem)();
+const StyledListItem = styled(ListItem)(({ theme }) => {
+  return css`
+    position: relative;
+    margin: 0 0 ${theme.spacing.padding.xs};
+    &::before {
+      position: absolute;
+      right: 101%;
+    }
+  `;
+});
 
 export default StyledListItem;

--- a/src/components/List/Item.js
+++ b/src/components/List/Item.js
@@ -1,0 +1,20 @@
+import styled from '@emotion/styled';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+export const ListItem = ({ children, ...otherProps }) => {
+  return <li {...otherProps}>{children}</li>;
+};
+
+ListItem.defaultProps = {
+  children: undefined,
+};
+
+ListItem.propTypes = {
+  /** @ignore */
+  children: PropTypes.node,
+};
+
+const StyledListItem = styled(ListItem)();
+
+export default StyledListItem;

--- a/src/components/List/Paragraph.js
+++ b/src/components/List/Paragraph.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export const ListParagraph = (props) => {
+  return <React.Fragment {...props} />;
+};
+
+export default ListParagraph;

--- a/src/components/List/README.md
+++ b/src/components/List/README.md
@@ -1,11 +1,13 @@
-A `<List>` is a collection of related elements of equal weight, presented in an itemised fashion:
+A `<List>` is a collection of related elements of equal weight, presented in an itemised fashion.
+
+Use the `<List.Item>` component for each item in your list.
 
 ```jsx
 <List numbered>
-  <List.Heading>To-do list</List.Heading>
-  <List.Item>Take shower 🛀</List.Item>
-  <List.Item>Brush teeth 😁</List.Item>
-  <List.Item>Take over world 🌍</List.Item>
+  <List.Heading>Things to do</List.Heading>
+  <List.Item>Take shower. 🛀</List.Item>
+  <List.Item>Brush teeth. 😁</List.Item>
+  <List.Item>Take over world. 🌍</List.Item>
 </List>
 ```
 
@@ -13,7 +15,6 @@ A `<List>` is a collection of related elements of equal weight, presented in an 
 
 Use a list to make blocks of text easier to read, and to break information into manageable chunks.
 
-Use the `<List.Item>` component for each item in your list.
 
 Don't use a `<List>` for:
 
@@ -37,9 +38,9 @@ Use a bulleted list when the order of items doesn't matter and to present conten
 
 ```jsx
 <List>
-  <List.Item>Cats</List.Item>
-  <List.Item>Dogs</List.Item>
-  <List.Item>Mice</List.Item>
+  <List.Item>cats</List.Item>
+  <List.Item>dogs</List.Item>
+  <List.Item>mice</List.Item>
 </List>
 ```
 
@@ -55,16 +56,17 @@ Use numbered lists when the order of the items is relevant, or to imply sequence
 ```jsx
 <List numbered>
   <List.Paragraph>How to file taxes:</List.Paragraph>
-  <List.Item>Obtain Wine</List.Item>
-  <List.Item>Open Wine</List.Item>
-  <List.Item>Consume Wine</List.Item>
-  <List.Item>Do taxes</List.Item>
+  <List.Item>Obtain wine.</List.Item>
+  <List.Item>Crack open wine.</List.Item>
+  <List.Item>Start drinking.</List.Item>
+  <List.Item>Spread papers in an organised fashion around room.</List.Item>
+  <List.Item>Reluctantly do taxes.</List.Item>
 </List>
 ```
 
 ## Voice & Tone
 
-- Introduce lists with a lead-in line ending in a colon (eg: "My favourite things:") or a `<Heading>` with no punctuation.
+- Introduce lists with a lead-in `<List.Paragraph>` ending in a colon (eg: "My favourite things:") or a `<List.Heading>` with no punctuation.
 - If list items use a single word only, start each item with a lowercase letter, and do not use a full stop at the end. (eg: "cat")
 - If list items use full sentences or sentence fragments (subject and verb), start each item with an uppercase letter and use a full stop at the end. (eg: "The cat ate a mouse.")
 - Never use commas or semicolons at the end of list items.
@@ -72,18 +74,22 @@ Use numbered lists when the order of the items is relevant, or to imply sequence
 
 ## Accessibility
 
-List items are conveyed as a group of related elements to assistive technology users.
+Using lists well will help improve the accessibility of your site.
 
-- If your list is described by a `<Heading />` or `<Paragraph />` component, put that component inside the list as the first component. This will identify it as the list header using the `aria-labelledby` attribute.
+List items are conveyed as a group of related elements to assistive technology users. Assistive technologies may announce the total number of items in a list, give the relevant position of each item in a list, and provide shortcuts to quickly traverse a list.
+
+- If your list has a title or lead-in phrase, use a `<List.Heading>` or `<List.Paragraph>` component, inside the list as the first component. This will identify it as the list header using the `aria-labelledby` attribute.
 - Keep list labels as short as possible to communicate your intent.
-- Use semantic HTML elements (`<ol>`, `<ul>`, and `<li>`) to mark up lists. This helps users of assistive technology navigate your list.
+- Use a bulleted list for lists where the order isn't important, and a numbered list when it is.
+- Don't use a list for stylistic or presentation needs only.
+- Use semantic HTML elements (`<ol>`, `<ul>`, and `<li>`) to mark up lists. (Nautilus will handle this for you!)
 
 ```jsx
 <List>
-  <List.Heading level={4}>Tasty Fruit</List.Heading>
-  <List.Item>Apples 🍏</List.Item>
-  <List.Item>Kiwis 🥝</List.Item>
-  <List.Item>Mangos 🥭</List.Item>
+  <List.Heading level={4}>Tasty fruit</List.Heading>
+  <List.Item>apples 🍏</List.Item>
+  <List.Item>kiwis 🥝</List.Item>
+  <List.Item>mangos 🥭</List.Item>
 </List>
 
 <List numbered>

--- a/src/components/List/README.md
+++ b/src/components/List/README.md
@@ -2,7 +2,7 @@ A `<List>` is a collection of related elements of equal weight, presented in a p
 
 ```jsx
 <List>
-	- thing one
+  - thing one
   - thing two
   - thing three
 </List>
@@ -10,7 +10,7 @@ A `<List>` is a collection of related elements of equal weight, presented in a p
 
 ```jsx
 <List numbered>
-	- thing one
+  - thing one
   - thing two
   - thing three
 </List>

--- a/src/components/List/README.md
+++ b/src/components/List/README.md
@@ -1,4 +1,4 @@
-A `<List>` is a collection of related elements of equal weight, presented in a parallel fashion. 
+A `<List>` is a collection of related elements of equal weight, presented in a parallel fashion.
 
 ```jsx
 <List>
@@ -6,3 +6,12 @@ A `<List>` is a collection of related elements of equal weight, presented in a p
   - thing two
   - thing three
 </List>
+```
+
+```jsx
+<List numbered>
+	- thing one
+  - thing two
+  - thing three
+</List>
+```

--- a/src/components/List/README.md
+++ b/src/components/List/README.md
@@ -1,17 +1,95 @@
-A `<List>` is a collection of related elements of equal weight, presented in a parallel fashion.
-
-```jsx
-<List>
-  - thing one
-  - thing two
-  - thing three
-</List>
-```
+A `<List>` is a collection of related elements of equal weight, presented in an itemised fashion:
 
 ```jsx
 <List numbered>
-  - thing one
-  - thing two
-  - thing three
+  <List.Heading>To-do list</List.Heading>
+  <List.Item>Take shower 🛀</List.Item>
+  <List.Item>Brush teeth 😁</List.Item>
+  <List.Item>Take over world 🌍</List.Item>
+</List>
+```
+
+## Usage
+
+Use a list to make blocks of text easier to read, and to break information into manageable chunks.
+
+Use the `<List.Item>` component for each item in your list.
+
+Don't use a `<List>` for:
+
+- A collection of unrelated items. Use a `<Paragraph>` instead, or break the collection into smaller lists of related items.
+- Presenting long or complex pieces of data. Use a `<Paragraph>` or a `<DataTable>` instead.
+- A list of checkboxes, radio buttons, or other elements that require user interactivity. Use a `<Choice>` instead.
+- A list of key/value pairs, such as a list of definitions or descriptions. Use a `<DescriptionList>` instead.
+
+## Appearance
+
+- Choose a bullet and numbering style and use them consistently across your site or app. Don't mix styles unless you have a good reason for doing so.
+- Avoid lists of more than ten items. If you have a long list, consider breaking it up into smaller, more specific lists for more meaning and comprehension.
+- Lists should use body text styling so they look identical to other body copy, especially when used in editorial copy. If a list stands alone, it can use more distinct typography.
+- The space between each individual list item should be slightly bigger than the line-height inside the list item.
+- Lists can be nested, but avoid too much nesting. As a general rule, nest lists to a maximum of three levels. If you need more levels, consider other ways of breaking up your content, like using an individual list for each top-level list item.
+- Arrange list items in a logical way, even if they aren't sequential numbered steps. Bulleted lists can be arranged by priority, by order of importance, by size, alphabetically, numerically.
+
+## Variations
+
+Use a bulleted list when the order of items doesn't matter and to present content of equal status or value. Bulleted lists can be rearranged without losing any meaning.
+
+```jsx
+<List>
+  <List.Item>Cats</List.Item>
+  <List.Item>Dogs</List.Item>
+  <List.Item>Mice</List.Item>
+</List>
+```
+
+<!--
+TODO: Implement an Icon list.
+Use an icon list when you want to provide additional semantic meaning—for instance, to show dos and don'ts.
+
+[example]
+-->
+
+Use numbered lists when the order of the items is relevant, or to imply sequence and order. They are commonly used when giving instructions or steps in a process.
+
+```jsx
+<List numbered>
+  <List.Paragraph>How to file taxes:</List.Paragraph>
+  <List.Item>Obtain Wine</List.Item>
+  <List.Item>Open Wine</List.Item>
+  <List.Item>Consume Wine</List.Item>
+  <List.Item>Do taxes</List.Item>
+</List>
+```
+
+## Voice & Tone
+
+- Introduce lists with a lead-in line ending in a colon (eg: "My favourite things:") or a `<Heading>` with no punctuation.
+- If list items use a single word only, start each item with a lowercase letter, and do not use a full stop at the end. (eg: "cat")
+- If list items use full sentences or sentence fragments (subject and verb), start each item with an uppercase letter and use a full stop at the end. (eg: "The cat ate a mouse.")
+- Never use commas or semicolons at the end of list items.
+- Use list items that are grammatically parallel to reflect their equal weight. For example, do not mix passive voice with active voice or declarative statements with imperative commands, and follow the same phrase structure for each item in the list.
+
+## Accessibility
+
+List items are conveyed as a group of related elements to assistive technology users.
+
+- If your list is described by a `<Heading />` or `<Paragraph />` component, put that component inside the list as the first component. This will identify it as the list header using the `aria-labelledby` attribute.
+- Keep list labels as short as possible to communicate your intent.
+- Use semantic HTML elements (`<ol>`, `<ul>`, and `<li>`) to mark up lists. This helps users of assistive technology navigate your list.
+
+```jsx
+<List>
+  <List.Heading level={4}>Tasty Fruit</List.Heading>
+  <List.Item>Apples 🍏</List.Item>
+  <List.Item>Kiwis 🥝</List.Item>
+  <List.Item>Mangos 🥭</List.Item>
+</List>
+
+<List numbered>
+  <List.Paragraph>The best motorcycles, in order:</List.Paragraph>
+  <List.Item>Honda CBR 125R</List.Item>
+  <List.Item>Honda CB400 Four</List.Item>
+  <List.Item>Ducati 848</List.Item>
 </List>
 ```

--- a/src/components/List/README.md
+++ b/src/components/List/README.md
@@ -1,0 +1,8 @@
+A `<List>` is a collection of related elements of equal weight, presented in a parallel fashion. 
+
+```jsx
+<List>
+	- thing one
+  - thing two
+  - thing three
+</List>

--- a/src/components/List/__snapshots__/index.test.js.snap
+++ b/src/components/List/__snapshots__/index.test.js.snap
@@ -1,0 +1,118 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`List List.Heading should render a heading outside the list if one is provided 1`] = `
+.emotion-2 {
+  color: #3b3f45;
+  margin: 0 0 3.2rem;
+  font-family: -apple-system,BlinkMacSystemFont,San Francisco,Roboto,Segoe UI,Helvetica Neue,sans-serif;
+  font-weight: 400;
+  font-size: 1.8rem;
+  line-height: 1.5555555555555556;
+  padding: 0;
+}
+
+.emotion-2 > .eo6n83v0 {
+  list-style: none;
+}
+
+.emotion-2 > .eo6n83v0::before {
+  content: '\\2022';
+  font-size: 0.6em;
+  line-height: 2.8;
+}
+
+.emotion-0 {
+  margin: 0 0 3.2rem;
+  font-family: -apple-system,BlinkMacSystemFont,San Francisco,Roboto,Segoe UI,Helvetica Neue,sans-serif;
+  font-weight: 700;
+  font-size: 4.4rem;
+  line-height: 1;
+}
+
+.eijrly0 + .emotion-0,
+ul + .emotion-0,
+ol + .emotion-0,
+dl + .emotion-0 {
+  margin-top: 3.2rem;
+}
+
+<div>
+  <h3
+    class="emotion-0 emotion-1"
+    data-testid="description"
+    id="fruits"
+  >
+    Tasty fruits
+  </h3>
+  <ul
+    aria-labelledby="fruits"
+    class="emotion-2 emotion-3"
+  />
+</div>
+`;
+
+exports[`List List.Paragraph should render a paragraph outside the list if one is provided 1`] = `
+.emotion-6 {
+  color: #3b3f45;
+  margin: 0 0 3.2rem;
+  font-family: -apple-system,BlinkMacSystemFont,San Francisco,Roboto,Segoe UI,Helvetica Neue,sans-serif;
+  font-weight: 400;
+  font-size: 1.8rem;
+  line-height: 1.5555555555555556;
+  padding: 0;
+}
+
+.emotion-6 > .emotion-3 {
+  list-style: none;
+}
+
+.emotion-6 > .emotion-3::before {
+  content: '\\2022';
+  font-size: 0.6em;
+  line-height: 2.8;
+}
+
+.emotion-2 {
+  position: relative;
+  margin: 0 0 0.4rem;
+}
+
+.emotion-2::before {
+  position: absolute;
+  right: 101%;
+}
+
+.emotion-0 {
+  color: #3b3f45;
+  margin: 0 0 3.2rem;
+  font-family: -apple-system,BlinkMacSystemFont,San Francisco,Roboto,Segoe UI,Helvetica Neue,sans-serif;
+  font-weight: 400;
+  font-size: 1.8rem;
+  line-height: 1.5555555555555556;
+}
+
+<div>
+  <p
+    class="emotion-0 emotion-1"
+    data-testid="description"
+    id="cars"
+  >
+    Here are some cars:
+  </p>
+  <ul
+    aria-labelledby="cars"
+    class="emotion-6 emotion-7"
+  >
+    <li
+      class="emotion-2 emotion-3"
+    >
+      Honda Civic
+    </li>
+    <li
+      class="emotion-2 emotion-3"
+    >
+      Ford Prefect
+    </li>
+  </ul>
+</div>
+`;

--- a/src/components/List/index.js
+++ b/src/components/List/index.js
@@ -1,3 +1,4 @@
+import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 import React, { Children, Fragment } from 'react';
@@ -99,7 +100,41 @@ List.propTypes = {
   numbered: PropTypes.bool,
 };
 
-const StyledList = styled(List)(textStyles);
+const StyledList = styled(List)(
+  ({ dark, inverse, large, light, numbered, small, theme }) => {
+    return css`
+      ${textStyles({ dark, inverse, large, light, small, theme })};
+      padding: 0;
+
+      ${numbered &&
+        css`
+          counter-reset: list-counter;
+
+          > ${ListItem} {
+            list-style: none;
+            counter-increment: list-counter;
+
+            &::before {
+              content: counter(list-counter) '. ';
+            }
+          }
+        `}
+
+      ${!numbered &&
+        css`
+          > ${ListItem} {
+            list-style: none;
+
+            &::before {
+              content: '\\2022';
+              font-size: 0.6em;
+              line-height: 2.8;
+            }
+          }
+        `}
+    `;
+  },
+);
 
 // Export ListHeading as `List.Heading`.
 StyledList.Heading = ListHeading;

--- a/src/components/List/index.js
+++ b/src/components/List/index.js
@@ -105,7 +105,6 @@ const StyledList = styled(List)(
     return css`
       ${textStyles({ dark, inverse, large, light, small, theme })};
       padding: 0;
-
       ${numbered &&
         css`
           counter-reset: list-counter;
@@ -119,7 +118,6 @@ const StyledList = styled(List)(
             }
           }
         `}
-
       ${!numbered &&
         css`
           > ${ListItem} {

--- a/src/components/List/index.js
+++ b/src/components/List/index.js
@@ -1,0 +1,75 @@
+import { css } from '@emotion/core';
+import styled from '@emotion/styled';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { bodySmall, bodyMedium, bodyLarge } from 'themes/mixins';
+
+export const List = ({
+  children,
+  large,
+  small,
+  inverse,
+  dark,
+  light,
+  ...otherProps
+}) => {
+  return <ul {...otherProps}>{children}</ul>;
+};
+
+List.defaultProps = {
+  children: undefined,
+  large: false,
+  small: false,
+  inverse: false,
+  dark: false,
+  light: false,
+};
+
+List.propTypes = {
+  /** @ignore */
+  children: PropTypes.node,
+  /** Increase the visual prominence of the paragraph. */
+  large: PropTypes.bool,
+  /** Decrease the visual prominence of the paragraph. */
+  small: PropTypes.bool,
+  /** Inverse text colour. Used for dark backgrounds. */
+  inverse: PropTypes.bool,
+  /** Darken text colour. */
+  dark: PropTypes.bool,
+  /** Lighten text colour. */
+  light: PropTypes.bool,
+};
+
+export default styled(List)(({ dark, inverse, large, light, small, theme }) => {
+  return css`
+      color: ${theme.colors.text.default};
+      margin: 0 0 ${theme.spacing.margin.m};
+      ${small && bodySmall(theme)};
+      ${!small && !large && bodyMedium(theme)};
+      ${large && bodyLarge(theme)};
+      ${light &&
+        css`
+          color: ${theme.colors.text.light};
+        `}
+
+      ${dark &&
+        css`
+          color: ${theme.colors.text.dark};
+        `}
+
+      ${inverse &&
+        css`
+          color: ${theme.colors.text.inverse};
+
+          ${light &&
+            css`
+              color: ${theme.colors.text.inverseLight};
+            `}
+          ${dark &&
+            css`
+              color: ${theme.colors.text.inverseDark};
+            `}
+        `}
+    `;
+});

--- a/src/components/List/index.js
+++ b/src/components/List/index.js
@@ -12,9 +12,21 @@ export const List = ({
   inverse,
   dark,
   light,
+  numbered,
   ...otherProps
 }) => {
-  return <ul {...otherProps}>{children}</ul>;
+  let Component = 'ul';
+  if (numbered === true) {
+    Component = 'ol';
+  }
+
+  return (
+    <Component {...otherProps}>
+      <li>thing one</li>
+      <li>thing two</li>
+      {children}
+    </Component>
+  );
 };
 
 List.defaultProps = {
@@ -24,6 +36,7 @@ List.defaultProps = {
   inverse: false,
   dark: false,
   light: false,
+  numbered: false,
 };
 
 List.propTypes = {
@@ -39,6 +52,8 @@ List.propTypes = {
   dark: PropTypes.bool,
   /** Lighten text colour. */
   light: PropTypes.bool,
+  /** Use numbers instead of bullets. */
+  numbered: PropTypes.bool,
 };
 
 export default styled(List)(({ dark, inverse, large, light, small, theme }) => {

--- a/src/components/List/index.test.js
+++ b/src/components/List/index.test.js
@@ -80,7 +80,7 @@ describe('List', () => {
 
   describe('List.Item', () => {
     it('should render a list item inside the list', () => {
-      const { container, getByTestId } = render(
+      const { getByTestId } = render(
         <List>
           <List.Item data-testid="one">hello</List.Item>
           <List.Item data-testid="two">goodbye</List.Item>

--- a/src/components/List/index.test.js
+++ b/src/components/List/index.test.js
@@ -1,0 +1,123 @@
+import React from 'react';
+
+import { render } from 'utils/testing';
+
+import List from '.';
+
+describe('List', () => {
+  it('should render a <ul> by default', () => {
+    const { container } = render(<List />);
+
+    expect(container.firstChild.tagName).toEqual('UL');
+  });
+
+  it('should render an <ol> when the numbered prop is true', () => {
+    const { container } = render(<List numbered />);
+
+    expect(container.firstChild.tagName).toEqual('OL');
+  });
+
+  it('should output its children', () => {
+    const { getByTestId } = render(
+      <List>
+        <List.Item data-testid="child">hello</List.Item>
+      </List>,
+    );
+
+    expect(getByTestId('child')).toBeDefined();
+  });
+
+  it('should not render non-List components as direct children', () => {
+    const { getByTestId } = render(
+      <List>
+        <div data-testid="child">hello</div>
+      </List>,
+    );
+
+    expect(() => {
+      getByTestId('child');
+    }).toThrow('Unable to find an element');
+  });
+
+  it('should not render regular <li> tags as direct children', () => {
+    const { getByTestId } = render(
+      <List>
+        <li data-testid="child">hello</li>
+      </List>,
+    );
+
+    expect(() => {
+      getByTestId('child');
+    }).toThrow('Unable to find an element');
+  });
+
+  describe('List.Heading', () => {
+    it('should render a heading outside the list if one is provided', () => {
+      const { container, getByTestId } = render(
+        <List>
+          <List.Heading level={3} id="fruits" data-testid="description">
+            Tasty fruits
+          </List.Heading>
+        </List>,
+      );
+
+      expect(getByTestId('description').tagName).toEqual('H3');
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should set a random, short unique ID for the heading if no ID was provided', () => {
+      const { getByTestId } = render(
+        <List numbered>
+          <List.Heading data-testid="description">My list</List.Heading>
+          <List.Item>One</List.Item>
+          <List.Item>Two</List.Item>
+        </List>,
+      );
+
+      expect(getByTestId('description').getAttribute('id')).toBeDefined();
+    });
+  });
+
+  describe('List.Item', () => {
+    it('should render a list item inside the list', () => {
+      const { container, getByTestId } = render(
+        <List>
+          <List.Item data-testid="one">hello</List.Item>
+          <List.Item data-testid="two">goodbye</List.Item>
+        </List>,
+      );
+
+      expect(getByTestId('one').tagName).toEqual('LI');
+      expect(getByTestId('two').tagName).toEqual('LI');
+    });
+  });
+
+  describe('List.Paragraph', () => {
+    it('should render a paragraph outside the list if one is provided', () => {
+      const { container, getByTestId } = render(
+        <List>
+          <List.Paragraph id="cars" data-testid="description">
+            Here are some cars:
+          </List.Paragraph>
+          <List.Item>Honda Civic</List.Item>
+          <List.Item>Ford Prefect</List.Item>
+        </List>,
+      );
+
+      expect(getByTestId('description').tagName).toEqual('P');
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should set a random, short unique ID for the paragraph if no ID was provided', () => {
+      const { getByTestId } = render(
+        <List numbered>
+          <List.Paragraph data-testid="description">My list</List.Paragraph>
+          <List.Item>One</List.Item>
+          <List.Item>Two</List.Item>
+        </List>,
+      );
+
+      expect(getByTestId('description').getAttribute('id')).toBeDefined();
+    });
+  });
+});

--- a/src/components/Paragraph/index.js
+++ b/src/components/Paragraph/index.js
@@ -1,9 +1,8 @@
-import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import { bodySmall, bodyMedium, bodyLarge } from 'themes/mixins';
+import { textStyles } from 'themes/mixins';
 
 export const Paragraph = ({
   children,
@@ -41,37 +40,6 @@ Paragraph.propTypes = {
   light: PropTypes.bool,
 };
 
-export default styled(Paragraph)(
-  ({ dark, inverse, large, light, small, theme }) => {
-    return css`
-      color: ${theme.colors.text.default};
-      margin: 0 0 ${theme.spacing.margin.m};
-      ${small && bodySmall(theme)};
-      ${!small && !large && bodyMedium(theme)};
-      ${large && bodyLarge(theme)};
-      ${light &&
-        css`
-          color: ${theme.colors.text.light};
-        `}
+const StyledParagraph = styled(Paragraph)(textStyles);
 
-      ${dark &&
-        css`
-          color: ${theme.colors.text.dark};
-        `}
-
-      ${inverse &&
-        css`
-          color: ${theme.colors.text.inverse};
-
-          ${light &&
-            css`
-              color: ${theme.colors.text.inverseLight};
-            `}
-          ${dark &&
-            css`
-              color: ${theme.colors.text.inverseDark};
-            `}
-        `}
-    `;
-  },
-);
+export default StyledParagraph;

--- a/src/themes/mixins.js
+++ b/src/themes/mixins.js
@@ -1,3 +1,5 @@
+import { css } from '@emotion/core';
+
 // Let's start by generating a type scale, along with line-heights and small-caps modifiers.
 // These functions will be used by our type styles below.
 
@@ -225,4 +227,37 @@ export const metadataLarge = (theme) => {
     }),
     ...smallCaps(),
   };
+};
+
+export const textStyles = ({ dark, inverse, large, light, small, theme }) => {
+  return css`
+    color: ${theme.colors.text.default};
+    margin: 0 0 ${theme.spacing.margin.m};
+    ${small && bodySmall(theme)};
+    ${!small && !large && bodyMedium(theme)};
+    ${large && bodyLarge(theme)};
+    ${light &&
+      css`
+        color: ${theme.colors.text.light};
+      `}
+
+    ${dark &&
+      css`
+        color: ${theme.colors.text.dark};
+      `}
+
+    ${inverse &&
+      css`
+        color: ${theme.colors.text.inverse};
+
+        ${light &&
+          css`
+            color: ${theme.colors.text.inverseLight};
+          `}
+        ${dark &&
+          css`
+            color: ${theme.colors.text.inverseDark};
+          `}
+      `}
+  `;
 };


### PR DESCRIPTION
Closes #50.

Draft of docs here: https://www.notion.so/octopusthink/List-1645bf94c66740ce805382c99be83de4

I've made it so it just borrows a bunch of props from the Paragraph component, since it would make sense to style these similarly. It does mean we're basically repeating a whole bunch of code, so we may end up wanting to have some sort of base Text component for components like these at some point (Quote comes to mind, for instance, although that might use slightly different styling, so maybe not?) but for now some repetition is probably fine. 

Here's what else I think we need here:

- [x] Review + add docs (@tofumatt )
- [x] Add an optional Heading prop
- [x] Add a prop to swap between bulleted and numbered lists
- [x] Implement an icon list variant (reliant on #14 and probably best done as an enhancement ticket)
- [x] Figure out the best way to handle the individual list items (@tofumatt)

I've tagged you in the items I'm not sure how to handle, but I may need help with the other ones too—I'm going to see how far I get now.

For the last item especially, I'm not sure how to do this exactly. 
I do like the format in the README, so maybe we can work backwards from there and see if we can build the API to make it super easy to make a list? Also, I'm betting this could be weird with Markdown processing, so I'm super out of my depth here.