### PR TITLE
fix: Use global emotion styles for styleguide

### DIFF
--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -9,20 +9,6 @@ module.exports = {
   },
   title: 'Nautilus Design System',
   skipComponentsWithoutExample: true,
-  styles: {
-    StyleGuide: {
-      '@global html': {
-        fontSize: '62.5%',
-        boxSizing: 'border-box',
-      },
-      '@global body': {
-        fontSize: '1.6rem',
-      },
-      '@global img': {
-        maxWidth: '100%',
-      },
-    },
-  },
   // For a full list of available components we can override, see:
   // https://github.com/styleguidist/react-styleguidist/tree/0f461ab8f5070d5e91e8911bc2b22d805c07fb98/src/client/rsg-components
   styleguideComponents: {

--- a/styleguide/components/StyleGuide/index.js
+++ b/styleguide/components/StyleGuide/index.js
@@ -2,7 +2,7 @@
 // https://github.com/styleguidist/react-styleguidist/blob/0f461ab8f5070d5e91e8911bc2b22d805c07fb98/src/client/rsg-components/StyleGuide/StyleGuide.js,
 // but adds a `<Nautilus>` wrapper so we can use our own components as
 // the output components of React Styleguidist's Markdown.
-import { css } from '@emotion/core';
+import { Global, css } from '@emotion/core';
 import PropTypes from 'prop-types';
 import React from 'react';
 import Markdown from 'rsg-components/Markdown';
@@ -22,6 +22,22 @@ export const StyleGuide = ({
 }) => {
   return (
     <Nautilus>
+      <Global
+        styles={css`
+          html {
+            box-sizing: border-box;
+            font-size: 62.5%;
+          }
+
+          body {
+            font-size: 1.6rem;
+          }
+
+          img {
+            max-width: 100%;
+          }
+        `}
+      />
       <div
         css={css`
           display: grid;


### PR DESCRIPTION
Fixes #58.

Might as well take this for a spin locally, but it looks like:

<img width="1433" alt="Screenshot 2019-06-06 at 02 21 11" src="https://user-images.githubusercontent.com/90871/59000306-c13f3280-8801-11e9-8aa9-540e8f2cc9db.png">

again. 😄