### PR TITLE
fix: Improve error message in custom prop type message

### DIFF
--- a/src/components/ui/List/Item.js
+++ b/src/components/ui/List/Item.js
@@ -31,4 +31,6 @@ ListItem.propTypes = {
   children: PropTypes.node,
 };
 
+ListItem.displayName = 'List.Item';
+
 export default styled(ListItem)(styles);

--- a/src/utils/CustomPropTypes.js
+++ b/src/utils/CustomPropTypes.js
@@ -22,7 +22,7 @@ const allowedChildren = (...types) => {
               (element) =>
                 getUnstyledComponentName(element.displayName) || element,
             )
-            .join(', ')}.`,
+            .join(', ')}. You tried to use: "${child.type}".`,
         );
       }
     });


### PR DESCRIPTION
Tweak the error message to make it clear which component you _are_ using when getting this error message.