### PR TITLE
docs: Add reference to commit conventions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ npm run lint
 
 Please read (`CONTRIBUTING.md`) for details on our code of conduct and the process for submitting pull requests.
 
+We use the [Conventional Commits](https://www.conventionalcommits.org/) specification for commit messages to ensure that commit messages are written in a consistent and predictable way.
+
 ## Versioning
 
 We use [SemVer](http://semver.org/) for versioning. For the versions available, see the [releases page](https://github.com/octopusthink/nautilus/releases).


### PR DESCRIPTION
...because I keep forgetting the rules, so I'm sure other people might too.

Once we expand the "Contributing" section into a CONTRIBUTING.md, we should probably expand on what additional prefixes are cool, how to name branches, provide a bunch of examples, etc.

I assume we are following this: https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716

...but I am okay with being corrected!