### PR TITLE
Hierarchy refactoring of docs

### DIFF
--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -41,6 +41,10 @@ module.exports = {
       __dirname,
       'styleguide/components/StyleGuide',
     ),
+    SectionHeadingRenderer: path.join(
+      __dirname,
+      'styleguide/components/SectionHeading',
+    ),
     TabButtonRenderer: path.join(__dirname, 'styleguide/components/TabButton'),
     TableRenderer: path.join(__dirname, 'styleguide/components/Table'),
     TableOfContentsRenderer: path.join(

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -27,6 +27,14 @@ module.exports = {
       'styleguide/components/Playground',
     ),
     PropsRenderer: path.join(__dirname, 'styleguide/components/Props'),
+    'slots/CodeTabButton': path.join(
+      __dirname,
+      'styleguide/components/slots/CodeTabButton',
+    ),
+    'slots/UsageTabButton': path.join(
+      __dirname,
+      'styleguide/components/slots/UsageTabButton',
+    ),
     // This wraps all actual page content in a `<Nautilus>` provider so
     // the content we output from Markdown has a theme available.
     StyleGuideRenderer: path.join(

--- a/styleguide/components/ComponentsList/index.js
+++ b/styleguide/components/ComponentsList/index.js
@@ -24,6 +24,7 @@ export function ComponentsList({ classes, items }) {
         list-style-type: none;
         display: grid;
         grid-gap: ${toUnits(theme.spacing.margin.medium)};
+        margin-top: 1.2rem;
 
         ul & {
           display: block;

--- a/styleguide/components/Playground/index.js
+++ b/styleguide/components/Playground/index.js
@@ -43,7 +43,6 @@ export function Playground({
         `}
       >
         <div>{tabButtons}</div>
-        <div>{toolbar}</div>
       </div>
       <div>{tabBody}</div>
     </div>

--- a/styleguide/components/Playground/index.js
+++ b/styleguide/components/Playground/index.js
@@ -39,7 +39,7 @@ export function Playground({
           display: flex;
           justify-content: space-between;
           align-items: center;
-          padding: ${toUnits(theme.spacing.padding.small)} ${toUnits(theme.spacing.padding.medium)};
+          padding: 0 ${toUnits(theme.spacing.padding.extraSmall)};
         `}
       >
         <div>{tabButtons}</div>

--- a/styleguide/components/SectionHeading/index.js
+++ b/styleguide/components/SectionHeading/index.js
@@ -5,30 +5,40 @@ import Heading from 'rsg-components/Heading';
 
 import theme from 'styleguide/theme';
 
-function SectionHeadingRenderer({ children, toolbar, id, href, depth, deprecated }) {
-	// const headingLevel = Math.min(6, depth);
-	// Overwrite RSG's classification of headings, since we're only using top-level headings here!
-	const headingLevel = 1;
+function SectionHeadingRenderer({
+  children,
+  toolbar,
+  id,
+  href,
+  depth,
+  deprecated,
+}) {
+  // const headingLevel = Math.min(6, depth);
+  // Overwrite RSG's classification of headings, since we're only using top-level headings here!
+  const headingLevel = 1;
 
-	return (
-			<Heading level={headingLevel} id={id}>
-				<a href={href} css={css`
-					text-decoration: none;
-					color: ${theme.colors.text.default};
-				`}>
-					{children}
-				</a>
-			</Heading>
-	);
+  return (
+    <Heading level={headingLevel} id={id}>
+      <a
+        href={href}
+        css={css`
+          text-decoration: none;
+          color: ${theme.colors.text.default};
+        `}
+      >
+        {children}
+      </a>
+    </Heading>
+  );
 }
 
 SectionHeadingRenderer.propTypes = {
-	children: PropTypes.node,
-	toolbar: PropTypes.node,
-	id: PropTypes.string.isRequired,
-	href: PropTypes.string.isRequired,
-	depth: PropTypes.number.isRequired,
-	deprecated: PropTypes.bool,
+  children: PropTypes.node,
+  toolbar: PropTypes.node,
+  id: PropTypes.string.isRequired,
+  href: PropTypes.string.isRequired,
+  depth: PropTypes.number.isRequired,
+  deprecated: PropTypes.bool,
 };
 
 export default SectionHeadingRenderer;

--- a/styleguide/components/SectionHeading/index.js
+++ b/styleguide/components/SectionHeading/index.js
@@ -1,0 +1,34 @@
+import { css } from '@emotion/core';
+import React from 'react';
+import PropTypes from 'prop-types';
+import Heading from 'rsg-components/Heading';
+
+import theme from 'styleguide/theme';
+
+function SectionHeadingRenderer({ children, toolbar, id, href, depth, deprecated }) {
+	// const headingLevel = Math.min(6, depth);
+	// Overwrite RSG's classification of headings, since we're only using top-level headings here!
+	const headingLevel = 1;
+
+	return (
+			<Heading level={headingLevel} id={id}>
+				<a href={href} css={css`
+					text-decoration: none;
+					color: ${theme.colors.text.default};
+				`}>
+					{children}
+				</a>
+			</Heading>
+	);
+}
+
+SectionHeadingRenderer.propTypes = {
+	children: PropTypes.node,
+	toolbar: PropTypes.node,
+	id: PropTypes.string.isRequired,
+	href: PropTypes.string.isRequired,
+	depth: PropTypes.number.isRequired,
+	deprecated: PropTypes.bool,
+};
+
+export default SectionHeadingRenderer;

--- a/styleguide/components/StyleGuide/index.js
+++ b/styleguide/components/StyleGuide/index.js
@@ -37,6 +37,16 @@ export const StyleGuide = ({
           img {
             max-width: 100%;
           }
+
+          h2 {
+            margin-top: ${theme.spacing.margin.xxl} !important;
+            border-top: 3px solid;
+            padding-top: ${theme.spacing.padding.xl};
+          }
+
+          h3 {
+            margin-top: ${theme.spacing.margin.l} !important;
+          }
         `}
       />
       <div

--- a/styleguide/components/StyleGuide/index.js
+++ b/styleguide/components/StyleGuide/index.js
@@ -49,7 +49,7 @@ export const StyleGuide = ({
           }
 
           .rsg--wrapper-11 > h2 {
-            margin-top: 0 !important;
+            margin: 0 !important;
             padding-top: 0;
             border-top: 0;
           }

--- a/styleguide/components/StyleGuide/index.js
+++ b/styleguide/components/StyleGuide/index.js
@@ -39,13 +39,13 @@ export const StyleGuide = ({
           }
 
           h2 {
-            margin-top: ${theme.spacing.margin.xxl} !important;
+            margin-top: ${toUnits(theme.spacing.margin.xxl)} !important;
             border-top: 3px solid;
-            padding-top: ${theme.spacing.padding.xl};
+            padding-top: ${toUnits(theme.spacing.padding.extraLarge)};
           }
 
           h3 {
-            margin-top: ${theme.spacing.margin.l} !important;
+            margin-top: ${toUnits(theme.spacing.margin.large)} !important;
           }
         `}
       />

--- a/styleguide/components/StyleGuide/index.js
+++ b/styleguide/components/StyleGuide/index.js
@@ -38,6 +38,10 @@ export const StyleGuide = ({
             max-width: 100%;
           }
 
+          h1 {
+            margin: 0 0 ${toUnits(theme.spacing.margin.extraLarge)};
+          }
+
           h2 {
             margin-top: ${toUnits(theme.spacing.margin.xxl)} !important;
             border-top: 3px solid;

--- a/styleguide/components/StyleGuide/index.js
+++ b/styleguide/components/StyleGuide/index.js
@@ -48,6 +48,12 @@ export const StyleGuide = ({
             padding-top: ${toUnits(theme.spacing.padding.extraLarge)};
           }
 
+          .rsg--wrapper-11 > h2 {
+            margin-top: 0 !important;
+            padding-top: 0;
+            border-top: 0;
+          }
+
           h3 {
             margin-top: ${toUnits(theme.spacing.margin.large)} !important;
           }

--- a/styleguide/components/TabButton/index.js
+++ b/styleguide/components/TabButton/index.js
@@ -3,32 +3,27 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import theme from 'styleguide/theme';
-import { interfaceUI } from 'styles';
-
+import { interfaceUI, toUnits } from 'styles';
 
 export function TabButtonRenderer({ name, className, onClick, active, children }) {
 	return (
 		<button css={css`
-			background: none;
+			background: ${theme.colors.neutral.black};
 			border: none;
-			color: ${theme.colors.neutral.white};
-			padding: 10px;
+			color: ${theme.colors.text.inverseLight};
+			padding: ${toUnits(theme.spacing.padding.medium)};
 			${css(interfaceUI.small(theme))};
-
-			.rsg--tabButtons-7 & {
-				color: hotpink !important;
-			}
 
 			&::before {
 				display: inline-block;
 				content: '↓';
-				margin-right: ${theme.spacing.padding.xxs};
+				margin-right: ${toUnits(theme.spacing.padding.extraSmall)};
 			}
 
 			${active &&
 			 css`
-				color: hotpink !important;
-				border-bottom: 2px solid hotpink;
+				color: ${theme.colors.text.inverseDark} !important;
+				border-bottom: 2px solid ${theme.colors.text.inverseDark};
 
 				&::before {
 					content: '↑';

--- a/styleguide/components/slots/CodeTabButton.js
+++ b/styleguide/components/slots/CodeTabButton.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import TabButton from 'rsg-components/TabButton';
+
+const CodeTabButton = props => <TabButton {...props}>Code</TabButton>;
+
+CodeTabButton.propTypes = {
+	onClick: PropTypes.func.isRequired,
+	name: PropTypes.string.isRequired,
+	active: PropTypes.bool,
+};
+
+export default CodeTabButton;

--- a/styleguide/components/slots/UsageTabButton.js
+++ b/styleguide/components/slots/UsageTabButton.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import TabButton from 'rsg-components/TabButton';
+import isEmpty from 'lodash/isEmpty';
+
+const UsageTabButton = props => {
+	const component = props.props;
+	const showButton = !isEmpty(component.props) || !isEmpty(component.methods);
+	return showButton ? <TabButton {...props}>Props</TabButton> : null;
+};
+
+UsageTabButton.propTypes = {
+	onClick: PropTypes.func.isRequired,
+	name: PropTypes.string.isRequired,
+	props: PropTypes.shape({
+		props: PropTypes.array,
+		methods: PropTypes.array,
+	}).isRequired,
+	active: PropTypes.bool,
+};
+
+export default UsageTabButton;


### PR DESCRIPTION
This is an attempt to make the styleguide a bit more usable & readable. It may or may not look super different.

<img width="1142" alt="Screenshot 2019-07-05 at 23 59 58" src="https://user-images.githubusercontent.com/376315/60747953-07162480-9f81-11e9-9bcf-81382c19f3df.png">

I'd kinda love it if we could put an intro paragraph under the title, _then_ the "props" drop-down, but that may be harder. The props table itself still needs some work, but it would help to get your @tofumatt's opinion from a developer perspective about how we could make it more readable. (I have some thoughts, but I'd love to know how it's working for you since I expect you might  look at this more than me!)

A big improvement I think we could make here is making the sidebar navigation more self-contained—so maybe a slide-in (and out) element that would default to open on large screens, and closed for smaller ones. Something along these lines: https://tympanus.net/Blueprints/SlidePushMenus/  I've also been trying to add selected styling, but I've been struggling thanks to #106.

We may also want to figure out a way of implenting sticky Tabs (available as of #108!) to make navigating between the major sections easier, but I suspect that's going to be a bit tricky.

Probably all of the above I can file as separate issues, and we can go ahead and merge this now. 