### PR TITLE
fix: Use forwardRef for all components

### DIFF
--- a/src/components/inline/Emphasis/index.js
+++ b/src/components/inline/Emphasis/index.js
@@ -1,13 +1,17 @@
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { forwardRef } from 'react';
 
-export const Emphasis = (props) => {
+export const Emphasis = forwardRef((props, ref) => {
   const { children, ...otherProps } = props;
 
-  return <em {...otherProps}>{children}</em>;
-};
+  return (
+    <em ref={ref} {...otherProps}>
+      {children}
+    </em>
+  );
+});
 
 export const styles = (props) => {
   const { theme } = props;
@@ -29,5 +33,7 @@ Emphasis.propTypes = {
 };
 
 export const { defaultProps, propTypes } = Emphasis;
+
+Emphasis.displayName = 'Emphasis';
 
 export default styled(Emphasis)(styles);

--- a/src/components/inline/Emphasis/index.test.js
+++ b/src/components/inline/Emphasis/index.test.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { createRef } from 'react';
 
 import { render } from 'utils/testing';
 
@@ -35,5 +35,14 @@ describe('Emphasis', () => {
     const { container } = render(<Emphasis>hello</Emphasis>);
 
     expect(container).toMatchSnapshot();
+  });
+
+  it('should forward refs', () => {
+    const ref = createRef();
+
+    render(<Emphasis ref={ref}>Italicised text</Emphasis>);
+
+    expect(ref.current).not.toBeNull();
+    expect(ref.current.tagName).toEqual('EM');
   });
 });

--- a/src/components/inline/Strong/index.js
+++ b/src/components/inline/Strong/index.js
@@ -1,13 +1,17 @@
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { forwardRef } from 'react';
 
-export const Strong = (props) => {
+export const Strong = forwardRef((props, ref) => {
   const { children, ...otherProps } = props;
 
-  return <strong {...otherProps}>{children}</strong>;
-};
+  return (
+    <strong ref={ref} {...otherProps}>
+      {children}
+    </strong>
+  );
+});
 
 export const styles = (props) => {
   const { theme } = props;
@@ -29,5 +33,7 @@ Strong.propTypes = {
 };
 
 export const { defaultProps, propTypes } = Strong;
+
+Strong.displayName = 'Strong';
 
 export default styled(Strong)(styles);

--- a/src/components/inline/Strong/index.test.js
+++ b/src/components/inline/Strong/index.test.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { createRef } from 'react';
 
 import { render } from 'utils/testing';
 
@@ -35,5 +35,14 @@ describe('Strong', () => {
     const { container } = render(<Strong>hello</Strong>);
 
     expect(container).toMatchSnapshot();
+  });
+
+  it('should forward refs', () => {
+    const ref = createRef();
+
+    render(<Strong ref={ref}>Bold text</Strong>);
+
+    expect(ref.current).not.toBeNull();
+    expect(ref.current.tagName).toEqual('STRONG');
   });
 });

--- a/src/components/ui/Button/index.js
+++ b/src/components/ui/Button/index.js
@@ -2,7 +2,7 @@ import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import invariant from 'invariant';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { interfaceUI, toUnits } from 'styles';
 
@@ -20,7 +20,7 @@ export const qualityControl = (props) => {
   );
 };
 
-export const Button = (props) => {
+export const Button = forwardRef((props, ref) => {
   const {
     children,
     minimal,
@@ -45,11 +45,11 @@ export const Button = (props) => {
   return (
     // See: https://github.com/yannickcr/eslint-plugin-react/issues/1555
     // eslint-disable-next-line react/button-has-type
-    <Component disabled={!navigation && disabled} {...otherProps}>
+    <Component disabled={!navigation && disabled} ref={ref} {...otherProps}>
       {children}
     </Component>
   );
-};
+});
 
 export const styles = (props) => {
   const {
@@ -207,6 +207,8 @@ Button.propTypes = {
   /** HTML `type` attribute for the button. Defaults to `"button"`. */
   type: PropTypes.oneOf(['button', 'reset', 'submit']),
 };
+
+Button.displayName = 'Button';
 
 export const { defaultProps, propTypes } = Button;
 

--- a/src/components/ui/Button/index.test.js
+++ b/src/components/ui/Button/index.test.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { createRef } from 'react';
 
 import { muteConsole, render } from 'utils/testing';
 
@@ -101,5 +101,14 @@ describe('Button', () => {
     );
 
     expect(getByTestId('myButton').classList).toContain('custom-class');
+  });
+
+  it('should forward refs', () => {
+    const ref = createRef();
+
+    render(<Button ref={ref}>Ref button</Button>);
+
+    expect(ref.current).not.toBeNull();
+    expect(ref.current.tagName).toEqual('BUTTON');
   });
 });

--- a/src/components/ui/Heading/index.js
+++ b/src/components/ui/Heading/index.js
@@ -1,7 +1,7 @@
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { List, Paragraph } from 'components';
 import { heading, toUnits } from 'styles';
@@ -12,11 +12,16 @@ const SMALL = 4;
 
 const HeadingLevels = [LARGE, MEDIUM, SMALL];
 
-export const Heading = ({ children, level, ...otherProps }) => {
+export const Heading = forwardRef((props, ref) => {
+  const { children, level, ...otherProps } = props;
   const HeadingElement = `h${level}`;
 
-  return <HeadingElement {...otherProps}>{children}</HeadingElement>;
-};
+  return (
+    <HeadingElement {...otherProps} ref={ref}>
+      {children}
+    </HeadingElement>
+  );
+});
 
 export const styles = ({ level, theme }) => {
   return css`
@@ -45,5 +50,7 @@ Heading.propTypes = {
   /** Semantic hierarchy level of the `<h>` element in the markup (ex: `<h3>`). The more semantically important the level, the larger the heading will appear visually; an `<h2>` will be visually styled as "large" while an `<h4>` will be visually small. */
   level: PropTypes.oneOf(HeadingLevels),
 };
+
+Heading.displayName = 'Heading';
 
 export default styled(Heading)(styles);

--- a/src/components/ui/Heading/index.test.js
+++ b/src/components/ui/Heading/index.test.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { createRef } from 'react';
 
 import { render } from 'utils/testing';
 
@@ -65,5 +65,18 @@ describe('Heading', () => {
     );
 
     expect(getByTestId('heading').classList).toContain('custom-class');
+  });
+
+  it('should forward refs', () => {
+    const ref = createRef();
+
+    render(
+      <Heading level={4} ref={ref}>
+        Tiny heading
+      </Heading>,
+    );
+
+    expect(ref.current).not.toBeNull();
+    expect(ref.current.tagName).toEqual('H4');
   });
 });

--- a/src/components/ui/Icon/index.js
+++ b/src/components/ui/Icon/index.js
@@ -2,7 +2,7 @@ import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import Feather from 'feather-icons';
 import PropTypes from 'prop-types';
-import React, { useState, useMemo } from 'react';
+import React, { forwardRef, useState, useMemo } from 'react';
 import shortid from 'shortid';
 
 import { toUnits } from 'styles';
@@ -60,7 +60,7 @@ const defineIconSizes = (props) => {
   };
 };
 
-export const Icon = (props) => {
+export const Icon = forwardRef((props, ref) => {
   const {
     background,
     border,
@@ -123,7 +123,6 @@ export const Icon = (props) => {
         {...otherProps}
         aria-hidden={title ? undefined : true}
         aria-labelledby={title && titleId}
-        id={svgId}
         css={css`
           fill: ${fillColor};
           height: ${toUnits(size)};
@@ -145,6 +144,8 @@ export const Icon = (props) => {
               opacity: 0.8;
             `}
         `}
+        id={svgId}
+        ref={ref}
       >
         {title && <title id={titleId}>{title}</title>}
         {description && <desc id={descriptionId}>{description}</desc>}
@@ -156,7 +157,7 @@ export const Icon = (props) => {
       </svg>
     </span>
   );
-};
+});
 
 export const styles = (props) => {
   const { border, background, verticalAlign } = props;
@@ -250,6 +251,8 @@ Icon.propTypes = {
   /** A short description of this icon's content. Leave blank if the icon is entirely decorative. */
   title: PropTypes.string,
 };
+
+Icon.displayName = 'Icon';
 
 export const { defaultProps, propTypes } = Icon;
 

--- a/src/components/ui/Icon/index.test.js
+++ b/src/components/ui/Icon/index.test.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { createRef } from 'react';
 
 import { muteConsole, render } from 'utils/testing';
 
@@ -75,5 +75,14 @@ describe('Icon', () => {
         container.firstChild.firstChild.getAttribute('aria-hidden'),
       ).toBeNull();
     });
+  });
+
+  it('should forward refs', () => {
+    const ref = createRef();
+
+    render(<Icon name="archive" title="Paper filing box" ref={ref} />);
+
+    expect(ref.current).not.toBeNull();
+    expect(ref.current.tagName).toEqual('svg');
   });
 });

--- a/src/components/ui/Link/index.js
+++ b/src/components/ui/Link/index.js
@@ -1,19 +1,23 @@
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
-import React, { Fragment } from 'react';
+import React, { Fragment, forwardRef } from 'react';
 import { Link as ReactRouterLink } from 'react-router-dom';
 
 import { Icon } from 'components/ui/Icon';
 
-export const Link = (props) => {
+const LinkTag = 'a';
+
+export const Link = forwardRef((props, ref) => {
   const { children, external, to, useHref, ...otherProps } = props;
   const hrefOnly = external || useHref;
-  const LinkComponent = hrefOnly ? 'a' : ReactRouterLink;
+  const LinkComponent = hrefOnly ? LinkTag : ReactRouterLink;
 
   return (
     <LinkComponent
       href={hrefOnly ? to : undefined}
+      innerRef={LinkComponent === ReactRouterLink ? ref : undefined}
+      ref={LinkComponent === LinkTag ? ref : undefined}
       to={!hrefOnly ? to : undefined}
       {...otherProps}
     >
@@ -26,7 +30,7 @@ export const Link = (props) => {
       )}
     </LinkComponent>
   );
-};
+});
 
 export const styles = (props) => {
   const { theme } = props;
@@ -68,6 +72,8 @@ Link.propTypes = {
   /** Set to true to disable react-router integration. */
   useHref: PropTypes.bool,
 };
+
+Link.displayName = 'Link';
 
 export const { defaultProps, propTypes } = Link;
 

--- a/src/components/ui/Link/index.test.js
+++ b/src/components/ui/Link/index.test.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { createRef } from 'react';
 
 import { muteConsole, renderWithRouter } from 'utils/testing';
 
@@ -74,5 +74,31 @@ describe('Link', () => {
     );
 
     expect(container).toMatchSnapshot();
+  });
+
+  it('should forward refs when using ReactRouterLink', () => {
+    const ref = createRef();
+
+    renderWithRouter(
+      <Link to="/" ref={ref}>
+        Homepage
+      </Link>,
+    );
+
+    expect(ref.current).not.toBeNull();
+    expect(ref.current.tagName).toEqual('A');
+  });
+
+  it('should forward refs when using useHref', () => {
+    const ref = createRef();
+
+    renderWithRouter(
+      <Link ref={ref} to="/" useHref>
+        Homepage
+      </Link>,
+    );
+
+    expect(ref.current).not.toBeNull();
+    expect(ref.current.tagName).toEqual('A');
   });
 });

--- a/src/components/ui/List/Item.js
+++ b/src/components/ui/List/Item.js
@@ -1,15 +1,19 @@
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { toUnits } from 'styles';
 
-export const ListItem = (props) => {
+export const Item = forwardRef((props, ref) => {
   const { children, ...otherProps } = props;
 
-  return <li {...otherProps}>{children}</li>;
-};
+  return (
+    <li ref={ref} {...otherProps}>
+      {children}
+    </li>
+  );
+});
 
 export const styles = (props) => {
   const { theme } = props;
@@ -24,15 +28,17 @@ export const styles = (props) => {
   `;
 };
 
-ListItem.defaultProps = {
+Item.defaultProps = {
   children: undefined,
 };
 
-ListItem.propTypes = {
+Item.propTypes = {
   /** @ignore */
   children: PropTypes.node,
 };
 
-ListItem.displayName = 'List.Item';
+Item.displayName = 'List.Item';
 
-export default styled(ListItem)(styles);
+export const { defaultProps, propTypes } = Item;
+
+export default styled(Item)(styles);

--- a/src/components/ui/List/Item.test.js
+++ b/src/components/ui/List/Item.test.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { createRef } from 'react';
 
 import { render } from 'utils/testing';
 
@@ -29,5 +29,14 @@ describe('List.Item', () => {
     );
 
     expect(getByTestId('listItem').classList).toContain('foo');
+  });
+
+  it('should forward refs', () => {
+    const ref = createRef();
+
+    render(<List.Item ref={ref}>Puppies are cute.</List.Item>);
+
+    expect(ref.current).not.toBeNull();
+    expect(ref.current.tagName).toEqual('LI');
   });
 });

--- a/src/components/ui/List/index.js
+++ b/src/components/ui/List/index.js
@@ -5,6 +5,7 @@ import React, {
   Children,
   Fragment,
   cloneElement,
+  forwardRef,
   useMemo,
   useState,
 } from 'react';
@@ -15,20 +16,22 @@ import Paragraph from 'components/ui/Paragraph';
 import { bodyStyles } from 'styles';
 import { CustomPropTypes } from 'utils';
 
-import ListItem from './Item';
+import Item from './Item';
 
 export const ALLOWED_DESCRIPTION_COMPONENTS = [Heading, Paragraph];
 
-export const List = ({
-  children,
-  dark,
-  inverse,
-  large,
-  light,
-  ordered,
-  small,
-  ...otherProps
-}) => {
+export const List = forwardRef((props, ref) => {
+  const {
+    children,
+    dark,
+    inverse,
+    large,
+    light,
+    ordered,
+    small,
+    ...otherProps
+  } = props;
+
   let ListComponent = 'ul';
   if (ordered === true) {
     ListComponent = 'ol';
@@ -60,7 +63,7 @@ export const List = ({
 
   const items = useMemo(() => {
     return Children.toArray(children).filter((child) => {
-      return child.type === ListItem;
+      return child.type === Item;
     });
   }, [children]);
 
@@ -69,13 +72,14 @@ export const List = ({
       {description}
       <ListComponent
         aria-labelledby={description && description.props.id}
+        ref={ref}
         {...otherProps}
       >
         {items}
       </ListComponent>
     </Fragment>
   );
-};
+});
 
 export const styles = ({
   dark,
@@ -93,7 +97,7 @@ export const styles = ({
       css`
         counter-reset: list-counter;
 
-        > ${ListItem} {
+        > ${Item} {
           list-style: none;
           counter-increment: list-counter;
 
@@ -104,7 +108,7 @@ export const styles = ({
       `}
     ${!ordered &&
       css`
-        > ${ListItem} {
+        > ${Item} {
           list-style: none;
 
           &::before {
@@ -132,7 +136,7 @@ List.propTypes = {
   /** @ignore The list items for this list (using the `List.Item` component), as well as the optional list description `Heading` or `Paragraph` component. */
   children: CustomPropTypes.allowedChildren(
     ...ALLOWED_DESCRIPTION_COMPONENTS,
-    ListItem,
+    Item,
   ),
   /** Increase the visual prominence of the list. */
   large: PropTypes.bool,
@@ -148,9 +152,11 @@ List.propTypes = {
   ordered: PropTypes.bool,
 };
 
+List.displayName = 'List';
+
 const StyledList = styled(List)(styles);
 
-// Export ListItem as `List.Item`.
-StyledList.Item = ListItem;
+// Export Item as `List.Item`.
+StyledList.Item = Item;
 
 export default StyledList;

--- a/src/components/ui/List/index.test.js
+++ b/src/components/ui/List/index.test.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { createRef } from 'react';
 
 import { muteConsole, render } from 'utils/testing';
 
@@ -140,6 +140,31 @@ describe('List', () => {
     expect(originalDescriptionId).toEqual(
       getByTestId('firstDescription').getAttribute('id'),
     );
+  });
+
+  it('should forward refs', () => {
+    const ref = createRef();
+    const headingRef = createRef();
+    const itemRef = createRef();
+
+    render(
+      <List ordered ref={ref}>
+        <Heading level={3} ref={headingRef}>
+          My list
+        </Heading>
+        <List.Item ref={itemRef}>One</List.Item>
+        <List.Item>Two</List.Item>
+      </List>,
+    );
+
+    expect(ref.current).not.toBeNull();
+    expect(ref.current.tagName).toEqual('OL');
+
+    expect(headingRef.current).not.toBeNull();
+    expect(headingRef.current.tagName).toEqual('H3');
+
+    expect(itemRef.current).not.toBeNull();
+    expect(itemRef.current.tagName).toEqual('LI');
   });
 
   describe('described by Heading component', () => {

--- a/src/components/ui/PageTitle/index.js
+++ b/src/components/ui/PageTitle/index.js
@@ -1,15 +1,20 @@
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { pageTitle } from 'styles';
 
-export const PageTitle = ({ children, documentTitle, ...otherProps }) => {
+export const PageTitle = forwardRef((props, ref) => {
+  const { children, documentTitle, ...otherProps } = props;
   // const documentTitleToUse = documentTitle || children;
 
-  return <h1 {...otherProps}>{children}</h1>;
-};
+  return (
+    <h1 ref={ref} {...otherProps}>
+      {children}
+    </h1>
+  );
+});
 
 export const styles = ({ theme }) => {
   return css`
@@ -28,5 +33,9 @@ PageTitle.propTypes = {
   /** String to pass to the `<DocumentTitle />` tag if the children of your `<PageTitle />` are more than just text content. */
   documentTitle: PropTypes.string,
 };
+
+PageTitle.displayName = 'PageTitle';
+
+export const { defaultProps, propTypes } = PageTitle;
 
 export default styled(PageTitle)(styles);

--- a/src/components/ui/PageTitle/index.test.js
+++ b/src/components/ui/PageTitle/index.test.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { createRef } from 'react';
 
 import { render } from 'utils/testing';
 
@@ -25,5 +25,14 @@ describe('PageTitle', () => {
     const { container } = render(<PageTitle>My Blog Posts</PageTitle>);
 
     expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('should forward refs', () => {
+    const ref = createRef();
+
+    render(<PageTitle ref={ref}>Puppies are cute.</PageTitle>);
+
+    expect(ref.current).not.toBeNull();
+    expect(ref.current.tagName).toEqual('H1');
   });
 });

--- a/src/components/ui/Paragraph/index.js
+++ b/src/components/ui/Paragraph/index.js
@@ -2,7 +2,7 @@ import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import invariant from 'invariant';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { bodyStyles } from 'styles';
 
@@ -20,13 +20,17 @@ export const qualityControl = (props) => {
   );
 };
 
-export const Paragraph = (props) => {
+export const Paragraph = forwardRef((props, ref) => {
   const { children, large, small, inverse, dark, light, ...otherProps } = props;
 
   qualityControl(props);
 
-  return <p {...otherProps}>{children}</p>;
-};
+  return (
+    <p ref={ref} {...otherProps}>
+      {children}
+    </p>
+  );
+});
 
 export const styles = ({ theme, ...otherProps }) => {
   return css`
@@ -57,6 +61,8 @@ Paragraph.propTypes = {
   /** Lighten text colour. */
   light: PropTypes.bool,
 };
+
+Paragraph.displayName = 'Paragraph';
 
 export const { defaultProps, propTypes } = Paragraph;
 

--- a/src/components/ui/Paragraph/index.test.js
+++ b/src/components/ui/Paragraph/index.test.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { createRef } from 'react';
 
 import { render } from 'utils/testing';
 
@@ -51,5 +51,14 @@ describe('Paragraph', () => {
     );
 
     expect(getByTestId('myText').classList).toContain('custom-class');
+  });
+
+  it('should forward refs', () => {
+    const ref = createRef();
+
+    render(<Paragraph ref={ref}>Puppies are cute.</Paragraph>);
+
+    expect(ref.current).not.toBeNull();
+    expect(ref.current.tagName).toEqual('P');
   });
 });

--- a/src/components/ui/Tabs/Tab.js
+++ b/src/components/ui/Tabs/Tab.js
@@ -14,7 +14,7 @@ export const Tab = forwardRef((props, ref) => {
   }
 
   return (
-    <section role="tabpanel" tabIndex="-1" {...otherProps} ref={ref}>
+    <section role="tabpanel" tabIndex="-1" ref={ref} {...otherProps}>
       <Heading level={4}>{label}</Heading>
 
       {children}
@@ -56,5 +56,7 @@ Tab.propTypes = {
 };
 
 Tab.displayName = 'Tabs.Tab';
+
+export const { defaultProps, propTypes } = Tab;
 
 export default styled(Tab)(styles);

--- a/src/components/ui/Tabs/Tab.test.js
+++ b/src/components/ui/Tabs/Tab.test.js
@@ -1,23 +1,23 @@
-import React from 'react';
+import React, { createRef } from 'react';
 
 import { muteConsole, render } from 'utils/testing';
 
 import { Paragraph } from 'components';
-import Tab from './Tab';
+import Tabs from '.';
 
-describe('Tabs.Tab', () => {
+describe('Tabs.Tabs.Tabs.Tab', () => {
   it('should render nothing when no children are provided', () => {
     muteConsole({ times: 1, type: 'error' });
-    const { container } = render(<Tab />);
+    const { container } = render(<Tabs.Tab />);
 
     expect(container.firstChild).toBeNull();
   });
 
   it('should render a <section> tag', () => {
     const { container } = render(
-      <Tab label="About">
+      <Tabs.Tab label="About">
         <Paragraph>Puppies are cute.</Paragraph>
-      </Tab>,
+      </Tabs.Tab>,
     );
 
     expect(container.firstChild.tagName).toEqual('SECTION');
@@ -25,9 +25,9 @@ describe('Tabs.Tab', () => {
 
   it('should render the label inside an h4', () => {
     const { container } = render(
-      <Tab label="About">
+      <Tabs.Tab label="About">
         <Paragraph>Puppies are cute.</Paragraph>
-      </Tab>,
+      </Tabs.Tab>,
     );
 
     expect(container.firstChild.children[0].tagName).toEqual('H4');
@@ -35,21 +35,34 @@ describe('Tabs.Tab', () => {
 
   it('should render the children as-provided', () => {
     const { container } = render(
-      <Tab label="About">
+      <Tabs.Tab label="About">
         <Paragraph>Puppies are cute.</Paragraph>
-      </Tab>,
+      </Tabs.Tab>,
     );
 
     expect(container.firstChild.children[1].tagName).toEqual('P');
   });
 
-  it('should render styles for a Tab', () => {
+  it('should render styles for a Tabs.Tab', () => {
     const { container } = render(
-      <Tab label="About">
+      <Tabs.Tab label="About">
         <Paragraph>Puppies are cute.</Paragraph>
-      </Tab>,
+      </Tabs.Tab>,
     );
 
     expect(container).toMatchSnapshot();
+  });
+
+  it('should forward refs', () => {
+    const ref = createRef();
+
+    render(
+      <Tabs.Tab label="About" ref={ref}>
+        <Paragraph>Puppies are cute.</Paragraph>
+      </Tabs.Tab>,
+    );
+
+    expect(ref.current).not.toBeNull();
+    expect(ref.current.tagName).toEqual('SECTION');
   });
 });

--- a/src/components/ui/Tabs/__snapshots__/Tab.test.js.snap
+++ b/src/components/ui/Tabs/__snapshots__/Tab.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Tabs.Tab should render styles for a Tab 1`] = `
+exports[`Tabs.Tabs.Tabs.Tab should render styles for a Tabs.Tab 1`] = `
 .emotion-4 {
   display: none;
 }

--- a/src/components/ui/Tabs/index.js
+++ b/src/components/ui/Tabs/index.js
@@ -5,6 +5,7 @@ import React, {
   Children,
   Fragment,
   cloneElement,
+  forwardRef,
   useCallback,
   useEffect,
   useMemo,
@@ -19,7 +20,7 @@ import { CustomPropTypes } from 'utils';
 
 import Tab from './Tab';
 
-export const Tabs = (props) => {
+export const Tabs = forwardRef((props, ref) => {
   const { children, dark, inverse, light, id, ...otherProps } = props;
   const sectionToFocusRef = useRef();
   const tabToFocusRef = useRef();
@@ -120,6 +121,7 @@ export const Tabs = (props) => {
         const {
           onClick: onClickTab,
           onKeyDown: onKeyDownTab,
+          ref: refTab,
           ...otherTabProps
         } = labelProps;
 
@@ -180,7 +182,7 @@ export const Tabs = (props) => {
                   onKeyDownTab(event);
                 }
               }}
-              ref={focusedTab === index ? tabToFocusRef : undefined}
+              ref={focusedTab === index ? tabToFocusRef : refTab}
               role="tab"
               tabIndex={index !== activeTab ? '-1' : undefined}
               {...otherTabProps}
@@ -219,14 +221,14 @@ export const Tabs = (props) => {
   return (
     <Fragment>
       {labels && !!labels.length && (
-        <ul role="tablist" {...otherProps}>
+        <ul ref={ref} role="tablist" {...otherProps}>
           {labels}
         </ul>
       )}
       {tabPanels}
     </Fragment>
   );
-};
+});
 
 export const styles = (props) => {
   const { dark, inverse, large, light, small, theme } = props;
@@ -260,6 +262,10 @@ Tabs.propTypes = {
   /** Lighten text colour. */
   light: PropTypes.bool,
 };
+
+Tabs.displayName = 'Tabs';
+
+export const { defaultProps, propTypes } = Tabs;
 
 const StyledTabs = styled(Tabs)(styles);
 

--- a/src/components/ui/Tabs/index.test.js
+++ b/src/components/ui/Tabs/index.test.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { createRef } from 'react';
 
 import { fireEvent, render, wait, waitForElement } from 'utils/testing';
 
@@ -90,6 +90,29 @@ describe('Tabs', () => {
     const { container } = render(tabSet);
 
     expect(container).toMatchSnapshot();
+  });
+
+  it('should forward refs', () => {
+    const ref = createRef();
+    const labelRef = createRef();
+    const tabRef = createRef();
+
+    render(
+      <Tabs id="myTabSetWithRefs" ref={ref}>
+        <Tabs.Tab label="About" labelProps={{ ref: labelRef }} ref={tabRef}>
+          <Paragraph>Puppies are cute.</Paragraph>
+        </Tabs.Tab>
+      </Tabs>,
+    );
+
+    expect(ref.current).not.toBeNull();
+    expect(ref.current.tagName).toEqual('UL');
+
+    expect(labelRef.current).not.toBeNull();
+    expect(labelRef.current.tagName).toEqual('A');
+
+    expect(tabRef.current).not.toBeNull();
+    expect(tabRef.current.tagName).toEqual('SECTION');
   });
 
   describe('accessibility', () => {

--- a/src/components/ui/TextField/index.js
+++ b/src/components/ui/TextField/index.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import React, {
   Fragment,
   cloneElement,
+  forwardRef,
   useCallback,
   useMemo,
   useState,
@@ -23,7 +24,7 @@ const smallText = (props) => {
   `;
 };
 
-export const TextField = (props) => {
+export const TextField = forwardRef((props, ref) => {
   const {
     children,
     disabled,
@@ -232,6 +233,7 @@ export const TextField = (props) => {
         required={!optional && 'required'}
         onBlur={onBlurHandler}
         onFocus={onFocusHandler}
+        ref={ref}
         rows={multiline ? rows : undefined}
         maxLength={size}
         type={!multiline ? type : undefined}
@@ -241,7 +243,7 @@ export const TextField = (props) => {
       {children}
     </Fragment>
   );
-};
+});
 
 // We export all components as styled components to allow component targetting
 // in our styles, but because this component renders multiple DOM elements (
@@ -328,5 +330,9 @@ TextField.propTypes = {
     'week',
   ]),
 };
+
+TextField.displayName = 'TextField';
+
+export const { defaultProps, propTypes } = TextField;
 
 export default styled(TextField)(styles);

--- a/src/components/ui/TextField/index.test.js
+++ b/src/components/ui/TextField/index.test.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { createRef } from 'react';
 
 import { fireEvent, render } from 'utils/testing';
 
@@ -139,5 +139,14 @@ describe('TextField', () => {
     fireEvent.focus(getByTestId('focusInput'));
 
     expect(onFocus).toHaveBeenCalled();
+  });
+
+  it('should forward refs', () => {
+    const ref = createRef();
+
+    render(<TextField ref={ref} />);
+
+    expect(ref.current).not.toBeNull();
+    expect(ref.current.tagName).toEqual('INPUT');
   });
 });


### PR DESCRIPTION
Fixes #117.

This is possibly a bit overkill but because we're a component library I'm assuming users will want the ability to reference the underlying DOM elements and am liberally forwarding `ref`s for now.

@sarahmonster You can probably rumber-stamp this if it passes the tests; feel free to look through and let me know if anything is confusing.