### PR TITLE
docs: Add an HTML lang attr

### DIFF
--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -115,4 +115,7 @@ module.exports = {
       sectionDepth: 1,
     },
   ],
+  template: {
+    lang: 'en-CA',
+  },
 };

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -116,6 +116,6 @@ module.exports = {
     },
   ],
   template: {
-    lang: 'en-CA',
+    lang: 'en-GB',
   },
 };


### PR DESCRIPTION
Close #114.

I used `en-CA` because it seems to be how we write English. Debate me! 😉 