### PR TITLE
fix: Highlight intro link when no hash exists

### DIFF
--- a/styleguide/components/ComponentsList/index.js
+++ b/styleguide/components/ComponentsList/index.js
@@ -16,7 +16,7 @@ export function ComponentsList({ classes, items }) {
     return null;
   }
 
-  const windowHash = `${window.location.pathname}#/${getHash(window.location.hash)}`;
+  const windowHash = window.location.hash.length ? `${window.location.pathname}#/${getHash(window.location.hash)}` : `${window.location.pathname}#/Introduction`;
 
   return (
     <ul


### PR DESCRIPTION
If the styleguide is loaded without a hash (on master) the intro isn't selected in the menu. This changes that!

### Before
<img width="1030" alt="Screenshot 2019-07-11 12 37 48" src="https://user-images.githubusercontent.com/90871/61048038-b5362a00-a3d8-11e9-9740-b4189e0162e6.png">

### After
<img width="839" alt="Screenshot 2019-07-11 12 37 13" src="https://user-images.githubusercontent.com/90871/61048040-b8311a80-a3d8-11e9-8249-747e6e773efc.png">