### PR TITLE
feat: Show a leading icon for Danger, Warning, and Success buttons.

### DIFF
--- a/src/components/ui/Button/index.js
+++ b/src/components/ui/Button/index.js
@@ -9,6 +9,7 @@ import React, { forwardRef } from 'react';
 import { Link as UnstyledLink } from 'components/ui/Link';
 import { Icon } from 'components/ui/Icon';
 import { interfaceUI, toUnits } from 'styles';
+import { useTheme } from 'themes';
 
 export const qualityControl = (props) => {
   const { minimal, primary, success, warning, danger } = props;
@@ -40,6 +41,7 @@ export const Button = forwardRef((props, ref) => {
   } = props;
 
   qualityControl(props);
+  const theme = useTheme();
 
   let Component = 'button';
   if (navigation === true) {
@@ -51,15 +53,15 @@ export const Button = forwardRef((props, ref) => {
     otherProps.type = undefined;
   }
 
-  let leadingIcon;
+  let iconName;
   if (success === true) {
-    leadingIcon = <Icon name="check-circle" small />;
+    iconName = 'check-circle';
   }
   if (warning === true) {
-    leadingIcon = <Icon name="alert-circle" small />;
+    iconName = 'alert-circle';
   }
   if (danger === true) {
-    leadingIcon = <Icon name="x-circle" small />;
+    iconName = 'x-circle';
   }
 
   return (
@@ -70,8 +72,13 @@ export const Button = forwardRef((props, ref) => {
       ref={ref}
       {...otherProps}
     >
-      {leadingIcon}
-      {'\u00A0'}
+      <Icon
+        name={iconName}
+        small
+        css={css`
+          margin-right: ${toUnits(theme.spacing.padding.extraSmall)};
+        `}
+      />
       {children}
     </Component>
   );

--- a/src/components/ui/Button/index.js
+++ b/src/components/ui/Button/index.js
@@ -7,6 +7,7 @@ import React, { forwardRef } from 'react';
 // Import the non-styled Link so we don't have to overwrite Link styles if
 // the `navigation` prop is used by a button.
 import { Link as UnstyledLink } from 'components/ui/Link';
+import { Icon } from 'components/ui/Icon';
 import { interfaceUI, toUnits } from 'styles';
 
 export const qualityControl = (props) => {
@@ -50,6 +51,17 @@ export const Button = forwardRef((props, ref) => {
     otherProps.type = undefined;
   }
 
+  let leadingIcon;
+  if (success === true) {
+    leadingIcon = <Icon name="check-circle" small />;
+  }
+  if (warning === true) {
+    leadingIcon = <Icon name="alert-circle" small />;
+  }
+  if (danger === true) {
+    leadingIcon = <Icon name="x-circle" small />;
+  }
+
   return (
     // See: https://github.com/yannickcr/eslint-plugin-react/issues/1555
     // eslint-disable-next-line react/button-has-type
@@ -58,7 +70,7 @@ export const Button = forwardRef((props, ref) => {
       ref={ref}
       {...otherProps}
     >
-      {children}
+      {leadingIcon} {children}
     </Component>
   );
 });

--- a/src/components/ui/Button/index.js
+++ b/src/components/ui/Button/index.js
@@ -70,7 +70,9 @@ export const Button = forwardRef((props, ref) => {
       ref={ref}
       {...otherProps}
     >
-      {leadingIcon} {children}
+      {leadingIcon}
+      {'\u00A0'}
+      {children}
     </Component>
   );
 });


### PR DESCRIPTION
## Before
<img width="765" alt="Screenshot 2019-07-11 at 18 16 47" src="https://user-images.githubusercontent.com/376315/61074501-c64e5d80-a40f-11e9-8708-58df318cb6d2.png">

## After
<img width="729" alt="Screenshot 2019-07-11 at 19 11 30" src="https://user-images.githubusercontent.com/376315/61074477-b8004180-a40f-11e9-9d0c-852b6312ca92.png">


Fixes #142.