### PR TITLE
fix: Remove margin from external links.

### DIFF
--- a/src/components/ui/Link/index.js
+++ b/src/components/ui/Link/index.js
@@ -47,7 +47,14 @@ export const Link = (props) => {
       {external && (
         <React.Fragment>
           {' '}
-          <Icon name="external-link" title="External link" small />
+          <Icon
+            name="external-link"
+            title="External link"
+            small
+            css={css`
+              margin: 0;
+            `}
+          />
         </React.Fragment>
       )}
     </LinkComponent>


### PR DESCRIPTION
Fixes #173 and also fixes https://github.com/octopusthink/octopusthink.com/issues/14.

If we wind up removing margins from components entirely (#163), this may be moot, but for now, it solves the problem and I can stop feeling a little batty every time I see it.
