### PR TITLE
fix: Fine-tune button hover styles.

### DIFF
--- a/src/components/ui/Button/__snapshots__/index.test.js.snap
+++ b/src/components/ui/Button/__snapshots__/index.test.js.snap
@@ -20,8 +20,8 @@ exports[`Button should match styles 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   top: 0;
-  -webkit-transition: box-shadow 200ms;
-  transition: box-shadow 200ms;
+  -webkit-transition: all 200ms ease-in-out;
+  transition: all 200ms ease-in-out;
 }
 
 .emotion-0::-moz-focus-inner {
@@ -40,7 +40,9 @@ exports[`Button should match styles 1`] = `
 }
 
 .emotion-0:hover {
-  box-shadow: 0 2px 0 0 #94225f;
+  border-color: #94225f;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.25);
+  color: #94225f;
 }
 
 <button

--- a/src/components/ui/Button/index.js
+++ b/src/components/ui/Button/index.js
@@ -132,19 +132,6 @@ export const Button = (props) => {
           outline: none;
         }
 
-        &:hover {
-          ${!minimal &&
-            css`
-              border-color: ${currentButtonColorDark};
-              box-shadow: 0 2px 4px rgba(0, 0, 0, 0.25);
-            `}
-
-          ${!primary &&
-            css`
-              color: ${currentButtonColorDark};
-            `}
-        }
-
         // Primary styles
         ${primary &&
           css`
@@ -198,6 +185,19 @@ export const Button = (props) => {
               padding-right: 0;
             }
           `}
+
+        &:hover {
+          ${!minimal &&
+            css`
+              border-color: ${currentButtonColorDark};
+              box-shadow: 0 2px 4px rgba(0, 0, 0, 0.25);
+            `}
+
+          ${!primary &&
+            css`
+              color: ${currentButtonColorDark};
+            `}
+        }
       `}
       disabled={!navigation ? disabled : undefined}
       {...linkPropsToUse}

--- a/src/components/ui/Button/index.js
+++ b/src/components/ui/Button/index.js
@@ -164,13 +164,10 @@ export const Button = (props) => {
         // Minimal styles
         ${minimal &&
           css`
-            border-left: 0;
-            border-radius: 0;
-            border-right: 0;
-            border-top: 0;
+            background: transparent;
+            border: 0;
             padding-left: 0;
             padding-right: 0;
-            border: 0;
             position: relative;
 
             &::before {

--- a/src/components/ui/Button/index.js
+++ b/src/components/ui/Button/index.js
@@ -115,7 +115,7 @@ export const Button = (props) => {
         text-align: center;
         text-decoration: none;
         top: 0;
-        transition: box-shadow 200ms;
+        transition: all 200ms ease-in-out;
 
         &::-moz-focus-inner {
           border: 0;
@@ -133,13 +133,27 @@ export const Button = (props) => {
         }
 
         &:hover {
-          box-shadow: 0 2px 0 0 ${currentButtonColorDark};
+          ${!minimal &&
+            css`
+              border-color: ${currentButtonColorDark};
+              box-shadow: 0 2px 4px rgba(0, 0, 0, 0.25);
+            `}
+
+          ${!primary &&
+            css`
+              color: ${currentButtonColorDark};
+            `}
         }
 
+        // Primary styles
         ${primary &&
           css`
             background: ${currentButtonColor};
             color: ${theme.colors.buttons.neutral};
+
+            &:hover {
+              background-color: ${currentButtonColorDark};
+            }
 
             &:active {
               background: ${currentButtonColorDark};
@@ -147,6 +161,7 @@ export const Button = (props) => {
             }
           `}
 
+        // Minimal styles
         ${minimal &&
           css`
             border-left: 0;
@@ -155,6 +170,21 @@ export const Button = (props) => {
             border-top: 0;
             padding-left: 0;
             padding-right: 0;
+            border: 0;
+            position: relative;
+
+            &::before {
+              content: '';
+              position: absolute;
+              bottom: 0;
+              width: 0;
+              border-bottom: 2px solid ${currentButtonColorDark};
+              transition: all 200ms ease-in-out;
+            }
+
+            &:hover::before {
+              width: 100%;
+            }
           `}
 
         ${navigation &&
@@ -163,7 +193,7 @@ export const Button = (props) => {
               content: ' →';
               display: inline;
               padding-right: ${toUnits(theme.spacing.padding.xSmall)};
-              transition: all 200ms;
+              transition: all 200ms ease-in-out;
             }
 
             &:hover::after {


### PR DESCRIPTION
The hover styles were driving me bananas—they looked clunky and didn't work well. This isn't perfect yet (and should be more themeable!) but it's a  big improvement, especially for the default and navigation buttons.

## Before
![2019-09-23 21 21 41](https://user-images.githubusercontent.com/376315/65459613-30d83c80-de48-11e9-823d-daae40063fe1.gif)


## After
![2019-09-23 21 21 10](https://user-images.githubusercontent.com/376315/65459557-1a31e580-de48-11e9-8a67-aebf6328dc57.gif)


There's a wee issue where the → arrow doesn't appear for the default button until you hover over it:

![2019-09-23 21 11 45](https://user-images.githubusercontent.com/376315/65459423-c6270100-de47-11e9-9f98-dfa9d9ca3a4f.gif)

.... probably just a CSS bug I'm too tired to catch.