### PR TITLE
fix: Button :active state transition delay

### DIFF
--- a/src/components/ui/Button/__snapshots__/index.test.js.snap
+++ b/src/components/ui/Button/__snapshots__/index.test.js.snap
@@ -22,6 +22,8 @@ exports[`Button should match styles 1`] = `
   top: 0;
   -webkit-transition: all 200ms ease-in-out;
   transition: all 200ms ease-in-out;
+  -webkit-transition: top 100ms ease;
+  transition: top 100ms ease;
 }
 
 .emotion-0::-moz-focus-inner {

--- a/src/components/ui/Button/__snapshots__/index.test.js.snap
+++ b/src/components/ui/Button/__snapshots__/index.test.js.snap
@@ -22,8 +22,8 @@ exports[`Button should match styles 1`] = `
   top: 0;
   -webkit-transition: all 200ms ease-in-out;
   transition: all 200ms ease-in-out;
-  -webkit-transition: top 100ms ease;
-  transition: top 100ms ease;
+  -webkit-transition: top 0ms ease-out;
+  transition: top 0ms ease-out;
 }
 
 .emotion-0::-moz-focus-inner {

--- a/src/components/ui/Button/index.js
+++ b/src/components/ui/Button/index.js
@@ -116,6 +116,7 @@ export const Button = (props) => {
         text-decoration: none;
         top: 0;
         transition: all 200ms ease-in-out;
+        transition: top 100ms ease;
 
         &::-moz-focus-inner {
           border: 0;

--- a/src/components/ui/Button/index.js
+++ b/src/components/ui/Button/index.js
@@ -116,7 +116,7 @@ export const Button = (props) => {
         text-decoration: none;
         top: 0;
         transition: all 200ms ease-in-out;
-        transition: top 50ms ease-out;
+        transition: top 0ms ease-out;
 
         &::-moz-focus-inner {
           border: 0;

--- a/src/components/ui/Button/index.js
+++ b/src/components/ui/Button/index.js
@@ -116,7 +116,7 @@ export const Button = (props) => {
         text-decoration: none;
         top: 0;
         transition: all 200ms ease-in-out;
-        transition: top 100ms ease;
+        transition: top 50ms ease-out;
 
         &::-moz-focus-inner {
           border: 0;


### PR DESCRIPTION

Fix #181

It's worth testing and tweaking this. The other option here would be to unset the transition entirely (`0ms`) or use `50ms`. Let me know which you prefer, but I think this makes the movement of the button when clicking on it feel much more "immediate", which is a nicer UX.