### PR TITLE
fix: Improve Tag wrapping.

### DIFF
--- a/src/components/ui/Paragraph/index.js
+++ b/src/components/ui/Paragraph/index.js
@@ -24,7 +24,17 @@ export const qualityControl = (props) => {
 };
 
 export const Paragraph = (props) => {
-  const { children, className, large, small, inverse, dark, light, ...otherProps } = props;
+  const {
+    children,
+    className,
+    dark,
+    inverse,
+    large,
+    light,
+    small,
+    unstyled,
+    ...otherProps
+  } = props;
 
   qualityControl(props);
 
@@ -33,16 +43,20 @@ export const Paragraph = (props) => {
   return (
     <p
       className={classnames(ComponentClassName, className)}
-      css={css`
-        ${bodyStyles({
-          large,
-          small,
-          inverse,
-          dark,
-          light,
-          theme,
-        })}
-      `}
+      css={
+        unstyled
+          ? undefined
+          : css`
+              ${bodyStyles({
+                large,
+                small,
+                inverse,
+                dark,
+                light,
+                theme,
+              })}
+            `
+      }
       {...otherProps}
     >
       {children}
@@ -58,6 +72,7 @@ Paragraph.defaultProps = {
   inverse: false,
   dark: false,
   light: false,
+  unstyled: false,
 };
 
 Paragraph.propTypes = {
@@ -75,6 +90,8 @@ Paragraph.propTypes = {
   dark: PropTypes.bool,
   /** Lighten text colour. */
   light: PropTypes.bool,
+  /* @ignore Don't output any CSS styles. */
+  unstyled: PropTypes.bool,
 };
 
 export const { defaultProps, propTypes } = Paragraph;

--- a/src/components/ui/Tags/index.js
+++ b/src/components/ui/Tags/index.js
@@ -4,7 +4,7 @@ import React, { Children, cloneElement, Fragment, useMemo, useState } from 'reac
 import shortid from 'shortid';
 
 import List from 'components/ui/List';
-import Paragraph from 'components/ui/Paragraph';
+import VisuallyHidden from 'components/ui/VisuallyHidden';
 import { ComponentClassName as ListItemClassName } from 'components/ui/List/Item';
 
 import Tag from './Tag';
@@ -56,22 +56,7 @@ export const Tags = (props) => {
 
   return (
     <React.Fragment>
-      {label && (
-        <Paragraph // TODO: switch with VisuallyHidden component, once available.
-          css={css`
-            font-style: bold;
-            position: absolute;
-            left: -10000px;
-            top: auto;
-            width: 1px;
-            height: 1px;
-            overflow: hidden;
-          `}
-          id={generatedId}
-        >
-          {label}
-        </Paragraph>
-      )}
+      {label && <VisuallyHidden id={generatedId}>{label}</VisuallyHidden>}
       <WrapperComponent>{items}</WrapperComponent>
     </React.Fragment>
   );

--- a/src/components/ui/Tags/index.js
+++ b/src/components/ui/Tags/index.js
@@ -27,6 +27,7 @@ export const Tags = (props) => {
           aria-labelledby={label && generatedId}
           css={css`
             display: inline-flex;
+            flex-wrap: wrap;
             list-style: none;
             margin: 0;
             width: 100%;


### PR DESCRIPTION
Before:
<img width="521" alt="Screenshot 2020-02-02 at 01 27 08" src="https://user-images.githubusercontent.com/376315/73601535-29920f80-455b-11ea-8f3a-958feab80eb0.png">

After:
<img width="462" alt="Screenshot 2020-02-02 at 01 26 35" src="https://user-images.githubusercontent.com/376315/73601534-28f97900-455b-11ea-9f23-a6a231dc1aee.png">

Fixes #162.

Also replaces a custom Paragraph used for list title with our VisuallyHidden component, since it's now available for use.
