### PR TITLE
feat: Change link focus style to an outline.

### DIFF
--- a/src/components/ui/Link/__snapshots__/index.test.js.snap
+++ b/src/components/ui/Link/__snapshots__/index.test.js.snap
@@ -28,7 +28,7 @@ exports[`Link should output Link styles 1`] = `
 
 .emotion-0:focus {
   border-color: transparent;
-  box-shadow: #f5bbda 0px 0px 0px 3px;
+  box-shadow: #f5bbda 0 0 0 3px;
   outline: none;
 }
 

--- a/src/components/ui/Link/__snapshots__/index.test.js.snap
+++ b/src/components/ui/Link/__snapshots__/index.test.js.snap
@@ -27,9 +27,8 @@ exports[`Link should output Link styles 1`] = `
 }
 
 .emotion-0:focus {
-  background: #f5bbda;
-  border-color: #cd2f83;
-  color: #181b1c;
+  border-color: transparent;
+  box-shadow: #f5bbda 0px 0px 0px 3px;
   outline: none;
 }
 

--- a/src/components/ui/Link/index.js
+++ b/src/components/ui/Link/index.js
@@ -33,9 +33,8 @@ export const Link = (props) => {
               }
 
               &:focus {
-                background: ${theme.colors.state.interactive};
-                border-color: ${theme.colors.state.interactiveText};
-                color: ${theme.colors.text.dark};
+                border-color: transparent;
+                box-shadow: ${theme.colors.state.interactive} 0px 0px 0px 3px;
                 outline: none;
               }
             `

--- a/src/components/ui/Link/index.js
+++ b/src/components/ui/Link/index.js
@@ -34,7 +34,7 @@ export const Link = (props) => {
 
               &:focus {
                 border-color: transparent;
-                box-shadow: ${theme.colors.state.interactive} 0px 0px 0px 3px;
+                box-shadow: ${theme.colors.state.interactive} 0 0 0 3px;
                 outline: none;
               }
             `

--- a/src/components/ui/SkipLink/__snapshots__/index.test.js.snap
+++ b/src/components/ui/SkipLink/__snapshots__/index.test.js.snap
@@ -28,9 +28,8 @@ exports[`SkipLink should contain styles, including focus styles that reveal the 
 }
 
 .emotion-0:focus {
-  background: #f5bbda;
-  border-color: #cd2f83;
-  color: #181b1c;
+  border-color: transparent;
+  box-shadow: #f5bbda 0px 0px 0px 3px;
   outline: none;
 }
 

--- a/src/components/ui/SkipLink/__snapshots__/index.test.js.snap
+++ b/src/components/ui/SkipLink/__snapshots__/index.test.js.snap
@@ -29,7 +29,7 @@ exports[`SkipLink should contain styles, including focus styles that reveal the 
 
 .emotion-0:focus {
   border-color: transparent;
-  box-shadow: #f5bbda 0px 0px 0px 3px;
+  box-shadow: #f5bbda 0 0 0 3px;
   outline: none;
 }
 


### PR DESCRIPTION
This is more consistent with focus states used elsewhere (ie, for buttons) and avoids weirdness where sometimes the background is too dark, and the contrast gets shot, like this:

<img width="500" src="https://user-images.githubusercontent.com/376315/75727705-7a716100-5cdd-11ea-89b4-aa2fcd1eb129.png" />

Before:

<img width="657" alt="Screenshot 2020-03-12 at 15 54 21" src="https://user-images.githubusercontent.com/376315/76540294-dc6a5d00-6479-11ea-981d-b4abfa2ecd27.png">
<img width="655" alt="Screenshot 2020-03-12 at 15 55 02" src="https://user-images.githubusercontent.com/376315/76540297-dd9b8a00-6479-11ea-934d-a629e68231d8.png">

Ultimately, we'll want to rejig the Link (and Button) components to allow for super-flexible hover and focus styling, but for now, this should give us a more consistent and sensible default behaviour. See also #200, which I've just filed.

And it should help with https://github.com/octopusthink/getmicdrop.com/issues/11, which is basically why I'm bothering to fix this now. 😜 