### PR TITLE
feat: Allow for icons in TextField

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,7 @@ on:
 jobs:
   coverage:
     name: Coverage
+    needs: [unit]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master

--- a/src/components/ui/Icon/index.js
+++ b/src/components/ui/Icon/index.js
@@ -49,24 +49,24 @@ const defineIconSizes = (props) => {
 
 export const Icon = (props) => {
   const {
+    'data-testid': dataTestId,
     background,
     border,
     children,
     className,
-    'data-testid': dataTestId,
     description,
     fillColor,
     id,
-    name,
-    title,
-    xSmall,
-    small,
-    medium,
     large,
-    xLarge,
+    medium,
+    name,
     noMargin,
+    small,
     strokeColor,
+    title,
     verticalAlign,
+    xLarge,
+    xSmall,
     ...otherProps
   } = props;
 

--- a/src/components/ui/TextField/README.md
+++ b/src/components/ui/TextField/README.md
@@ -59,6 +59,29 @@ The text string to mark an optional field is customisable in your theme. **Do no
 <TextField label="I am optional" optional />
 ```
 
+### Icons
+
+You can use icons inside your `TextField` to increase clarity and confidence in your users.
+
+A **signifier icon** appears at the start of the field. Use a signifier icon as a way of indicating the type of input the `TextField` is expecting. For example: a search query, a telephone number, or a link.
+
+A **action icon** appears at the end of the field. Use an action icon to provide an additional control related to the field. You could use this icon to initiate a GPS lookup, to upload a file, or to clear the input and start over.
+
+```jsx
+import { Icon } from '@octopusthink/nautilus';
+const phoneIcon = <Icon name="phone" />;
+const searchIcon = <Icon name="search" />;
+const locateIcon = <Icon name="map-pin" />;
+const clearIcon = <Icon name="x-circle" />;
+
+<React.Fragment>
+  <TextField label="Phone" signifierIcon={phoneIcon} placeholder="A signifier (leading) icon hints at the input required" />
+  <TextField label="Location" actionIcon={locateIcon} placeholder="An action (trailing) icon is used as an additional control" />
+  <TextField label="Search" signifierIcon={searchIcon} actionIcon={clearIcon} />
+</React.Fragment>
+
+```
+
 ## Interaction
 
 ### Focus

--- a/src/components/ui/TextField/README.md
+++ b/src/components/ui/TextField/README.md
@@ -68,18 +68,11 @@ A **signifier icon** appears at the start of the field. Use a signifier icon as 
 A **action icon** appears at the end of the field. Use an action icon to provide an additional control related to the field. You could use this icon to initiate a GPS lookup, to upload a file, or to clear the input and start over.
 
 ```jsx
-import { Icon } from '@octopusthink/nautilus';
-const phoneIcon = <Icon name="phone" />;
-const searchIcon = <Icon name="search" />;
-const locateIcon = <Icon name="map-pin" />;
-const clearIcon = <Icon name="x-circle" />;
-
 <React.Fragment>
-  <TextField label="Phone" signifierIcon={phoneIcon} placeholder="A signifier (leading) icon hints at the input required" />
-  <TextField label="Location" actionIcon={locateIcon} placeholder="An action (trailing) icon is used as an additional control" />
-  <TextField label="Search" signifierIcon={searchIcon} actionIcon={clearIcon} />
+  <TextField label="Phone" signifierIcon="phone" placeholder="A signifier (leading) icon hints at the input required" />
+  <TextField label="Location" actionIcon="map-pin" placeholder="An action (trailing) icon is used as an additional control" />
+  <TextField label="Search" signifierIcon="search" actionIcon="x-circle" />
 </React.Fragment>
-
 ```
 
 ## Interaction

--- a/src/components/ui/TextField/README.md
+++ b/src/components/ui/TextField/README.md
@@ -61,11 +61,11 @@ The text string to mark an optional field is customisable in your theme. **Do no
 
 ### Icons
 
-You can use icons inside your `TextField` to increase clarity and confidence in your users.
+You can use icons inside your `TextField` to increase clarity and confidence for your users.
 
 A **signifier icon** appears at the start of the field. Use a signifier icon as a way of indicating the type of input the `TextField` is expecting. For example: a search query, a telephone number, or a link.
 
-A **action icon** appears at the end of the field. Use an action icon to provide an additional control related to the field. You could use this icon to initiate a GPS lookup, to upload a file, or to clear the input and start over.
+An **action icon** appears at the end of the field. Use the action icon to provide an additional control related to the field. You could use this icon to initiate a GPS lookup, to upload a file, or to clear/reset the input.
 
 ```jsx
 <React.Fragment>

--- a/src/components/ui/TextField/README.md
+++ b/src/components/ui/TextField/README.md
@@ -70,10 +70,17 @@ A **action icon** appears at the end of the field. Use an action icon to provide
 ```jsx
 <React.Fragment>
   <TextField label="Phone" signifierIcon="phone" placeholder="A signifier (leading) icon hints at the input required" />
-  <TextField label="Location" actionIcon="map-pin" placeholder="An action (trailing) icon is used as an additional control" />
-  <TextField label="Search" signifierIcon="search" actionIcon="x-circle" />
+  <TextField label="Location" actionIcon="map-pin" actionIconTitle="Locate me" placeholder="An action (trailing) icon is used as an additional control" />
+  <TextField label="Search" signifierIcon="search" actionIcon="x-circle" actionIconTitle="Clear field" />
 </React.Fragment>
 ```
+
+Since icons are only accessible to sighted users, it's best to provide a title so that screen reader users will understand your meaning.
+
+Generally speaking:
+- Provide a title for an action icon that describes the action to be taken.
+- Don't provide a title for a signifier icon unless it provides useful context that doesn't exist elsewhere. 
+- *Don't* provide a title if it just repeats the label text. 
 
 ## Interaction
 

--- a/src/components/ui/TextField/__snapshots__/index.test.js.snap
+++ b/src/components/ui/TextField/__snapshots__/index.test.js.snap
@@ -237,6 +237,49 @@ exports[`TextField should not set a \`max-width\` on the input element without a
 </div>
 `;
 
+exports[`TextField should output an <Icon> when the signifierIcon prop is used 1`] = `
+.emotion-0 {
+  font-family: -apple-system,BlinkMacSystemFont,San Francisco,Roboto,Segoe UI,Helvetica Neue,sans-serif;
+  font-weight: 500;
+  font-size: 1.8rem;
+  line-height: 1.3333333333333333;
+  color: #3b3f45;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1 0 50%;
+  -ms-flex: 1 0 50%;
+  flex: 1 0 50%;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  margin: 0 0 0.4rem;
+}
+
+.emotion-0:active {
+  color: #cd2f83;
+}
+
+.emotion-0:focus {
+  color: #cd2f83;
+}
+
+<label
+  class="emotion-0"
+  for="myTestId"
+>
+  Hello
+</label>
+`;
+
 exports[`TextField should set a \`max-width\` on the input element when \`size\` is set 1`] = `
 .emotion-0 {
   font-family: -apple-system,BlinkMacSystemFont,San Francisco,Roboto,Segoe UI,Helvetica Neue,sans-serif;

--- a/src/components/ui/TextField/__snapshots__/index.test.js.snap
+++ b/src/components/ui/TextField/__snapshots__/index.test.js.snap
@@ -237,6 +237,49 @@ exports[`TextField should not set a \`max-width\` on the input element without a
 </div>
 `;
 
+exports[`TextField should output an <Icon> when the actionIcon prop is used 1`] = `
+.emotion-0 {
+  font-family: -apple-system,BlinkMacSystemFont,San Francisco,Roboto,Segoe UI,Helvetica Neue,sans-serif;
+  font-weight: 500;
+  font-size: 1.8rem;
+  line-height: 1.3333333333333333;
+  color: #3b3f45;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1 0 50%;
+  -ms-flex: 1 0 50%;
+  flex: 1 0 50%;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  margin: 0 0 0.4rem;
+}
+
+.emotion-0:active {
+  color: #cd2f83;
+}
+
+.emotion-0:focus {
+  color: #cd2f83;
+}
+
+<label
+  class="emotion-0"
+  for="myTestId"
+>
+  Hello
+</label>
+`;
+
 exports[`TextField should output an <Icon> when the signifierIcon prop is used 1`] = `
 .emotion-0 {
   font-family: -apple-system,BlinkMacSystemFont,San Francisco,Roboto,Segoe UI,Helvetica Neue,sans-serif;

--- a/src/components/ui/TextField/__snapshots__/index.test.js.snap
+++ b/src/components/ui/TextField/__snapshots__/index.test.js.snap
@@ -1,6 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TextField should hide styles when unstyled prop is set 1`] = `
+.emotion-2 {
+  position: relative;
+}
+
 <div>
   <label
     class="emotion-0"
@@ -8,12 +12,16 @@ exports[`TextField should hide styles when unstyled prop is set 1`] = `
   >
     Hello
   </label>
-  <input
-    class="emotion-0"
-    id="myTextField"
-    required=""
-    type="text"
-  />
+  <div
+    class="emotion-2"
+  >
+    <input
+      class="emotion-0"
+      id="myTextField"
+      required=""
+      type="text"
+    />
+  </div>
 </div>
 `;
 
@@ -52,6 +60,10 @@ exports[`TextField should match styles 1`] = `
   color: #cd2f83;
 }
 
+.emotion-2 {
+  position: relative;
+}
+
 .emotion-1 {
   font-family: -apple-system,BlinkMacSystemFont,San Francisco,Roboto,Segoe UI,Helvetica Neue,sans-serif;
   font-weight: 500;
@@ -65,7 +77,8 @@ exports[`TextField should match styles 1`] = `
   display: block;
   margin: 0;
   outline: none;
-  padding: 1.2rem 1.2rem;
+  padding: 1.2rem;
+  position: relative;
   -webkit-transition: box-shadow 200ms;
   transition: box-shadow 200ms;
   width: 100%;
@@ -105,12 +118,16 @@ exports[`TextField should match styles 1`] = `
   >
     Hello
   </label>
-  <input
-    class="emotion-1"
-    id="myTextField"
-    required=""
-    type="text"
-  />
+  <div
+    class="emotion-2"
+  >
+    <input
+      class="emotion-1"
+      id="myTextField"
+      required=""
+      type="text"
+    />
+  </div>
 </div>
 `;
 
@@ -149,6 +166,10 @@ exports[`TextField should not set a \`max-width\` on the input element without a
   color: #cd2f83;
 }
 
+.emotion-2 {
+  position: relative;
+}
+
 .emotion-1 {
   font-family: -apple-system,BlinkMacSystemFont,San Francisco,Roboto,Segoe UI,Helvetica Neue,sans-serif;
   font-weight: 500;
@@ -162,7 +183,8 @@ exports[`TextField should not set a \`max-width\` on the input element without a
   display: block;
   margin: 0;
   outline: none;
-  padding: 1.2rem 1.2rem;
+  padding: 1.2rem;
+  position: relative;
   -webkit-transition: box-shadow 200ms;
   transition: box-shadow 200ms;
   width: 100%;
@@ -202,12 +224,16 @@ exports[`TextField should not set a \`max-width\` on the input element without a
   >
     Hello
   </label>
-  <input
-    class="emotion-1"
-    id="testInput"
-    required=""
-    type="text"
-  />
+  <div
+    class="emotion-2"
+  >
+    <input
+      class="emotion-1"
+      id="testInput"
+      required=""
+      type="text"
+    />
+  </div>
 </div>
 `;
 
@@ -246,6 +272,10 @@ exports[`TextField should set a \`max-width\` on the input element when \`size\`
   color: #cd2f83;
 }
 
+.emotion-2 {
+  position: relative;
+}
+
 .emotion-1 {
   font-family: -apple-system,BlinkMacSystemFont,San Francisco,Roboto,Segoe UI,Helvetica Neue,sans-serif;
   font-weight: 500;
@@ -259,7 +289,8 @@ exports[`TextField should set a \`max-width\` on the input element when \`size\`
   display: block;
   margin: 0;
   outline: none;
-  padding: 1.2rem 1.2rem;
+  padding: 1.2rem;
+  position: relative;
   -webkit-transition: box-shadow 200ms;
   transition: box-shadow 200ms;
   width: 100%;
@@ -300,13 +331,17 @@ exports[`TextField should set a \`max-width\` on the input element when \`size\`
   >
     Hello
   </label>
-  <input
-    class="emotion-1"
-    id="testInput"
-    maxlength="10"
-    required=""
-    type="text"
-  />
+  <div
+    class="emotion-2"
+  >
+    <input
+      class="emotion-1"
+      id="testInput"
+      maxlength="10"
+      required=""
+      type="text"
+    />
+  </div>
 </div>
 `;
 
@@ -345,6 +380,10 @@ exports[`TextField should set a \`max-width\` on the textarea element when \`siz
   color: #cd2f83;
 }
 
+.emotion-2 {
+  position: relative;
+}
+
 .emotion-1 {
   font-family: -apple-system,BlinkMacSystemFont,San Francisco,Roboto,Segoe UI,Helvetica Neue,sans-serif;
   font-weight: 500;
@@ -358,7 +397,8 @@ exports[`TextField should set a \`max-width\` on the textarea element when \`siz
   display: block;
   margin: 0;
   outline: none;
-  padding: 1.2rem 1.2rem;
+  padding: 1.2rem;
+  position: relative;
   -webkit-transition: box-shadow 200ms;
   transition: box-shadow 200ms;
   width: 100%;
@@ -399,13 +439,17 @@ exports[`TextField should set a \`max-width\` on the textarea element when \`siz
   >
     Hello
   </label>
-  <textarea
-    class="emotion-1"
-    id="testInput"
-    maxlength="10"
-    required=""
-    rows="4"
-  />
+  <div
+    class="emotion-2"
+  >
+    <textarea
+      class="emotion-1"
+      id="testInput"
+      maxlength="10"
+      required=""
+      rows="4"
+    />
+  </div>
 </div>
 `;
 
@@ -444,6 +488,10 @@ exports[`TextField shouldn't have a margin when \`noMargin\` is true 1`] = `
   color: #cd2f83;
 }
 
+.emotion-2 {
+  position: relative;
+}
+
 .emotion-1 {
   font-family: -apple-system,BlinkMacSystemFont,San Francisco,Roboto,Segoe UI,Helvetica Neue,sans-serif;
   font-weight: 500;
@@ -457,7 +505,8 @@ exports[`TextField shouldn't have a margin when \`noMargin\` is true 1`] = `
   display: block;
   margin: 0;
   outline: none;
-  padding: 1.2rem 1.2rem;
+  padding: 1.2rem;
+  position: relative;
   -webkit-transition: box-shadow 200ms;
   transition: box-shadow 200ms;
   width: 100%;
@@ -496,12 +545,16 @@ exports[`TextField shouldn't have a margin when \`noMargin\` is true 1`] = `
   >
     Hello
   </label>
-  <input
-    class="emotion-1"
-    id="myTextField"
-    required=""
-    type="text"
-  />
+  <div
+    class="emotion-2"
+  >
+    <input
+      class="emotion-1"
+      id="myTextField"
+      required=""
+      type="text"
+    />
+  </div>
 </div>
 `;
 
@@ -540,6 +593,10 @@ exports[`TextField shouldn't have a margin when \`noMargin\` is true and error e
   color: #cd2f83;
 }
 
+.emotion-2 {
+  position: relative;
+}
+
 .emotion-1 {
   font-family: -apple-system,BlinkMacSystemFont,San Francisco,Roboto,Segoe UI,Helvetica Neue,sans-serif;
   font-weight: 500;
@@ -553,7 +610,8 @@ exports[`TextField shouldn't have a margin when \`noMargin\` is true and error e
   display: block;
   margin: 0;
   outline: none;
-  padding: 1.2rem 1.2rem;
+  padding: 1.2rem;
+  position: relative;
   -webkit-transition: box-shadow 200ms;
   transition: box-shadow 200ms;
   width: 100%;
@@ -593,17 +651,21 @@ exports[`TextField shouldn't have a margin when \`noMargin\` is true and error e
   >
     Hello
   </label>
-  <input
-    aria-errormessage="errorMessage"
-    class="emotion-1"
-    id="myTextField"
-    required=""
-    type="text"
-  />
   <div
-    id="errorMessage"
+    class="emotion-2"
   >
-    Something went wrong!
+    <input
+      aria-errormessage="errorMessage"
+      class="emotion-1"
+      id="myTextField"
+      required=""
+      type="text"
+    />
+    <div
+      id="errorMessage"
+    >
+      Something went wrong!
+    </div>
   </div>
 </div>
 `;

--- a/src/components/ui/TextField/index.js
+++ b/src/components/ui/TextField/index.js
@@ -19,8 +19,10 @@ const smallText = (props) => {
 
 export const TextField = forwardRef((props, ref) => {
   const {
+    __actionIconId,
     __signifierIconId,
     actionIcon,
+    actionIconOnClick,
     actionIconTitle,
     children,
     disabled,
@@ -326,6 +328,9 @@ export const TextField = forwardRef((props, ref) => {
 
         {actionIcon && (
           <Icon
+            data-testid={__actionIconId}
+            id={__actionIconId}
+            onClick={actionIconOnClick}
             name={actionIcon}
             title={actionIconTitle}
             css={
@@ -349,8 +354,10 @@ export const TextField = forwardRef((props, ref) => {
 });
 
 TextField.defaultProps = {
+  __actionIconId: undefined,
   __signifierIconId: undefined,
   actionIcon: undefined,
+  actionIconOnClick: undefined,
   actionIconTitle: undefined,
   children: undefined,
   disabled: false,
@@ -373,10 +380,14 @@ TextField.defaultProps = {
 };
 
 TextField.propTypes = {
+  /** @ignore ID prop for the action icon <Icon /> component; only used for testing. */
+  __actionIconId: PropTypes.string,
   /** @ignore ID prop for the signifier icon <Icon /> component; only used for testing. */
   __signifierIconId: PropTypes.string,
   /** An action icon appears at the end of the input and indicates provides an additional control, like a drop-down or a geolocation. String refers to Icon `name` prop. */
   actionIcon: PropTypes.string,
+  /* Event handler for the action icon */
+  actionIconOnClick: PropTypes.func,
   /** Accessible title for the action icon. */
   actionIconTitle: PropTypes.string,
   /** @ignore */

--- a/src/components/ui/TextField/index.js
+++ b/src/components/ui/TextField/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import React, { cloneElement, forwardRef, useCallback, useMemo, useState } from 'react';
 import shortid from 'shortid';
 
+import Icon from 'components/ui/Icon';
 import { focusStyle, interfaceUI, toUnits } from 'styles';
 import { useTheme } from 'themes';
 
@@ -219,7 +220,7 @@ export const TextField = forwardRef((props, ref) => {
             css`
               margin: 0 0 ${toUnits(theme.spacing.margin.medium)};
             `}
-            
+
           ${signifierIcon &&
             css`
               padding-left: ${toUnits(
@@ -283,7 +284,8 @@ export const TextField = forwardRef((props, ref) => {
         />
 
         {signifierIcon && (
-          <span
+          <Icon
+            name={signifierIcon}
             css={
               unstyled
                 ? undefined
@@ -294,13 +296,12 @@ export const TextField = forwardRef((props, ref) => {
                     left: ${toUnits(theme.spacing.padding.medium)};
                   `
             }
-          >
-            {signifierIcon}
-          </span>
+          />
         )}
 
         {actionIcon && (
-          <span
+          <Icon
+            name={actionIcon}
             css={
               unstyled
                 ? undefined
@@ -311,9 +312,7 @@ export const TextField = forwardRef((props, ref) => {
                     right: ${toUnits(theme.spacing.padding.small)};
                   `
             }
-          >
-            {actionIcon}
-          </span>
+          />
         )}
 
         {errorComponent}
@@ -345,8 +344,8 @@ TextField.defaultProps = {
 };
 
 TextField.propTypes = {
-  /** An action icon appears at the end of the input and indicates provides an additional control, like a drop-down or a geolocation. */
-  actionIcon: PropTypes.node,
+  /** An action icon appears at the end of the input and indicates provides an additional control, like a drop-down or a geolocation. String refers to Icon `name` prop. */
+  actionIcon: PropTypes.string,
   /** @ignore */
   children: PropTypes.node,
   /** @ignore */
@@ -371,8 +370,8 @@ TextField.propTypes = {
   multiline: PropTypes.bool,
   /** Number of rows to provide when using a `multiline` input. Ignored when `multiline` is `false`. */
   rows: PropTypes.number,
-  /** A signifier icon appears at the start of the input and indicates what kind of data the field needs. */
-  signifierIcon: PropTypes.node,
+  /** A signifier icon appears at the start of the input and indicates what kind of data the field needs. String refers to Icon `name` prop. */
+  signifierIcon: PropTypes.string,
   /** Size defines the number of characters the field is intended to support. */
   size: PropTypes.number,
   /** Placeholder text, used only for examples. */

--- a/src/components/ui/TextField/index.js
+++ b/src/components/ui/TextField/index.js
@@ -6,6 +6,7 @@ import shortid from 'shortid';
 import Icon from 'components/ui/Icon';
 import { focusStyle, interfaceUI, toUnits } from 'styles';
 import { useTheme } from 'themes';
+import { unstable_renderSubtreeIntoContainer } from 'react-dom';
 
 const smallText = (props) => {
   const { theme } = props;
@@ -20,6 +21,7 @@ const smallText = (props) => {
 export const TextField = forwardRef((props, ref) => {
   const {
     actionIcon,
+    actionIconTitle,
     children,
     disabled,
     error,
@@ -35,6 +37,7 @@ export const TextField = forwardRef((props, ref) => {
     placeholder,
     rows,
     signifierIcon,
+    signifierIconTitle,
     size,
     type,
     unstyled,
@@ -286,6 +289,7 @@ export const TextField = forwardRef((props, ref) => {
         {signifierIcon && (
           <Icon
             name={signifierIcon}
+            title={signifierIconTitle}
             css={
               unstyled
                 ? undefined
@@ -302,6 +306,7 @@ export const TextField = forwardRef((props, ref) => {
         {actionIcon && (
           <Icon
             name={actionIcon}
+            title={actionIconTitle}
             css={
               unstyled
                 ? undefined
@@ -324,6 +329,7 @@ export const TextField = forwardRef((props, ref) => {
 
 TextField.defaultProps = {
   actionIcon: undefined,
+  actionIconTitle: undefined,
   children: undefined,
   disabled: false,
   error: undefined,
@@ -338,6 +344,7 @@ TextField.defaultProps = {
   placeholder: undefined,
   rows: 4,
   signifierIcon: undefined,
+  signifierIconTitle: undefined,
   size: undefined,
   type: 'text',
   unstyled: false,
@@ -346,6 +353,8 @@ TextField.defaultProps = {
 TextField.propTypes = {
   /** An action icon appears at the end of the input and indicates provides an additional control, like a drop-down or a geolocation. String refers to Icon `name` prop. */
   actionIcon: PropTypes.string,
+  /** Accessible title for the action icon. */
+  actionIconTitle: PropTypes.string,
   /** @ignore */
   children: PropTypes.node,
   /** @ignore */
@@ -372,6 +381,8 @@ TextField.propTypes = {
   rows: PropTypes.number,
   /** A signifier icon appears at the start of the input and indicates what kind of data the field needs. String refers to Icon `name` prop. */
   signifierIcon: PropTypes.string,
+  /** Accessible title for the signifier icon. */
+  signifierIconTitle: PropTypes.string,
   /** Size defines the number of characters the field is intended to support. */
   size: PropTypes.number,
   /** Placeholder text, used only for examples. */

--- a/src/components/ui/TextField/index.js
+++ b/src/components/ui/TextField/index.js
@@ -6,7 +6,6 @@ import shortid from 'shortid';
 import Icon from 'components/ui/Icon';
 import { focusStyle, interfaceUI, toUnits } from 'styles';
 import { useTheme } from 'themes';
-import { unstable_renderSubtreeIntoContainer } from 'react-dom';
 
 const smallText = (props) => {
   const { theme } = props;

--- a/src/components/ui/TextField/index.js
+++ b/src/components/ui/TextField/index.js
@@ -320,8 +320,8 @@ export const TextField = forwardRef((props, ref) => {
         )}
 
         {errorComponent}
-        {children}
       </div>
+      {children}
     </React.Fragment>
   );
 });

--- a/src/components/ui/TextField/index.js
+++ b/src/components/ui/TextField/index.js
@@ -18,21 +18,23 @@ const smallText = (props) => {
 
 export const TextField = forwardRef((props, ref) => {
   const {
+    actionIcon,
     children,
     disabled,
     error,
+    hint,
+    id,
     label,
     labelId,
-    id,
-    placeholder,
-    onBlur,
-    onFocus,
-    hint,
     multiline,
     noMargin,
-    rows,
-    size,
+    onBlur,
+    onFocus,
     optional,
+    placeholder,
+    rows,
+    signifierIcon,
+    size,
     type,
     unstyled,
     ...otherProps
@@ -187,12 +189,17 @@ export const TextField = forwardRef((props, ref) => {
           )}
         </label>
       )}
-      <InputComponent
-        aria-errormessage={errorId}
-        css={
-          unstyled
-            ? undefined
-            : css`
+      <div
+        css={css`
+          position: relative;
+        `}
+      >
+        <InputComponent
+          aria-errormessage={errorId}
+          css={
+            unstyled
+              ? undefined
+              : css`
           ${interfaceUI.medium(theme)};
           background: ${theme.colors.buttons.neutral};
           border-radius: 0;
@@ -202,8 +209,8 @@ export const TextField = forwardRef((props, ref) => {
           display: block;
           margin: 0;
           outline: none;
-          padding: ${toUnits(theme.spacing.padding.medium)}
-            ${toUnits(theme.spacing.padding.medium)};
+          padding: ${toUnits(theme.spacing.padding.medium)};
+          position: relative;
           transition: box-shadow 200ms;
           width: 100%;
 
@@ -211,6 +218,20 @@ export const TextField = forwardRef((props, ref) => {
             !error &&
             css`
               margin: 0 0 ${toUnits(theme.spacing.margin.medium)};
+            `}
+            
+          ${signifierIcon &&
+            css`
+              padding-left: ${toUnits(
+                theme.components.Icon.sizes.medium.size + theme.spacing.padding.small * 2,
+              )};
+            `}
+
+          ${actionIcon &&
+            css`
+              padding-right: ${toUnits(
+                theme.components.Icon.sizes.medium.size + theme.spacing.padding.small * 2,
+              )};
             `}
 
           ${size &&
@@ -247,26 +268,63 @@ export const TextField = forwardRef((props, ref) => {
             color: ${theme.colors.text.light};
           }
         `
-        }
-        disabled={disabled}
-        id={inputId}
-        placeholder={placeholder}
-        required={!optional && 'required'}
-        onBlur={onBlurHandler}
-        onFocus={onFocusHandler}
-        ref={ref}
-        rows={multiline ? rows : undefined}
-        maxLength={size}
-        type={!multiline ? type : undefined}
-        {...otherProps}
-      />
-      {errorComponent}
-      {children}
+          }
+          disabled={disabled}
+          id={inputId}
+          placeholder={placeholder}
+          required={!optional && 'required'}
+          onBlur={onBlurHandler}
+          onFocus={onFocusHandler}
+          ref={ref}
+          rows={multiline ? rows : undefined}
+          maxLength={size}
+          type={!multiline ? type : undefined}
+          {...otherProps}
+        />
+
+        {signifierIcon && (
+          <span
+            css={
+              unstyled
+                ? undefined
+                : css`
+                    opacity: 0.8;
+                    position: absolute;
+                    top: ${toUnits(theme.spacing.padding.medium + 2)};
+                    left: ${toUnits(theme.spacing.padding.medium)};
+                  `
+            }
+          >
+            {signifierIcon}
+          </span>
+        )}
+
+        {actionIcon && (
+          <span
+            css={
+              unstyled
+                ? undefined
+                : css`
+                    opacity: 0.8;
+                    position: absolute;
+                    top: ${toUnits(theme.spacing.padding.medium + 2)};
+                    right: ${toUnits(theme.spacing.padding.small)};
+                  `
+            }
+          >
+            {actionIcon}
+          </span>
+        )}
+
+        {errorComponent}
+        {children}
+      </div>
     </React.Fragment>
   );
 });
 
 TextField.defaultProps = {
+  actionIcon: undefined,
   children: undefined,
   disabled: false,
   error: undefined,
@@ -280,12 +338,15 @@ TextField.defaultProps = {
   optional: false,
   placeholder: undefined,
   rows: 4,
+  signifierIcon: undefined,
   size: undefined,
   type: 'text',
   unstyled: false,
 };
 
 TextField.propTypes = {
+  /** An action icon appears at the end of the input and indicates provides an additional control, like a drop-down or a geolocation. */
+  actionIcon: PropTypes.node,
   /** @ignore */
   children: PropTypes.node,
   /** @ignore */
@@ -310,6 +371,8 @@ TextField.propTypes = {
   multiline: PropTypes.bool,
   /** Number of rows to provide when using a `multiline` input. Ignored when `multiline` is `false`. */
   rows: PropTypes.number,
+  /** A signifier icon appears at the start of the input and indicates what kind of data the field needs. */
+  signifierIcon: PropTypes.node,
   /** Size defines the number of characters the field is intended to support. */
   size: PropTypes.number,
   /** Placeholder text, used only for examples. */

--- a/src/components/ui/TextField/index.test.js
+++ b/src/components/ui/TextField/index.test.js
@@ -153,6 +153,22 @@ describe('TextField', () => {
     expect(container).toMatchSnapshot();
   });
 
+  it('should output an <Icon> when the signifierIcon prop is used', () => {
+    const { container, getByTestId } = render(
+      <TextField
+        __signifierIconId="signifierIcon"
+        signifierIcon="phone"
+        data-testid="focusInput"
+        label="Hello"
+        id="myTestId"
+      />,
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+    expect(getByTestId('signifierIcon').tagName).toEqual('SPAN');
+    expect(getByTestId('signifierIcon').firstChild.tagName).toEqual('svg');
+  });
+
   it('should forward refs', () => {
     const ref = createRef();
 

--- a/src/components/ui/TextField/index.test.js
+++ b/src/components/ui/TextField/index.test.js
@@ -5,21 +5,23 @@ import { axe, fireEvent, muteConsole, render } from 'utils/testing';
 import TextField from '.';
 
 describe('TextField', () => {
-  it('should render a <label> and <input> by default', () => {
+  it('should render a <label> and <div><input></div> by default', () => {
     const { container } = render(<TextField label="Hello" />);
 
     expect(container.children[0].tagName).toEqual('LABEL');
-    expect(container.children[1].tagName).toEqual('INPUT');
+    expect(container.children[1].tagName).toEqual('DIV');
+    expect(container.children[1].children[0].tagName).toEqual('INPUT');
   });
 
   it('should not output an empty <label> if one is not supplied', () => {
     muteConsole({ times: 1, type: 'error' });
     const { container } = render(<TextField />);
 
-    expect(container.children[0].tagName).toEqual('INPUT');
+    expect(container.children[0].tagName).toEqual('DIV');
+    expect(container.children[0].children[0].tagName).toEqual('INPUT');
   });
 
-  it('will render `children` after the <label> and <input> elements', () => {
+  it('will render `children` after the <label> and <div><input></div> elements', () => {
     const { container } = render(
       <TextField label="Hello">
         <span>Why is this even here? I dunno</span>
@@ -27,15 +29,17 @@ describe('TextField', () => {
     );
 
     expect(container.children[0].tagName).toEqual('LABEL');
-    expect(container.children[1].tagName).toEqual('INPUT');
+    expect(container.children[1].tagName).toEqual('DIV');
+    expect(container.children[1].children[0].tagName).toEqual('INPUT');
     expect(container.children[2].tagName).toEqual('SPAN');
   });
 
-  it('should render a <label> and <textarea> when `multiline` is `true`', () => {
+  it('should render a <label> and <div><textarea></div> when `multiline` is `true`', () => {
     const { container } = render(<TextField label="Hello" multiline />);
 
     expect(container.children[0].tagName).toEqual('LABEL');
-    expect(container.children[1].tagName).toEqual('TEXTAREA');
+    expect(container.children[1].tagName).toEqual('DIV');
+    expect(container.children[1].children[0].tagName).toEqual('TEXTAREA');
   });
 
   it('should set rows to 4 by default', () => {

--- a/src/components/ui/TextField/index.test.js
+++ b/src/components/ui/TextField/index.test.js
@@ -169,6 +169,66 @@ describe('TextField', () => {
     expect(getByTestId('signifierIcon').firstChild.tagName).toEqual('svg');
   });
 
+  it('should focus the text field when the signifier icon is clicked', () => {
+    const ref = createRef();
+
+    const { getByTestId } = render(
+      <TextField
+        __signifierIconId="signifierIcon"
+        signifierIcon="phone"
+        data-testid="focusInput"
+        label="Hello"
+        id="myTestId"
+        ref={ref}
+      />,
+    );
+
+    const focusSpy = jest.spyOn(ref.current, 'focus');
+
+    // The onClick event gets attached to the SVG child element, so make sure
+    // that's what we click on.
+    fireEvent.click(getByTestId('signifierIcon').firstChild);
+
+    expect(focusSpy).toHaveBeenCalled();
+  });
+
+  it('should output an <Icon> when the actionIcon prop is used', () => {
+    const { container, getByTestId } = render(
+      <TextField
+        __actionIconId="arnoldIcon"
+        actionIcon="phone"
+        data-testid="focusInput"
+        label="Hello"
+        id="myTestId"
+      />,
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+    expect(getByTestId('arnoldIcon').tagName).toEqual('SPAN');
+    expect(getByTestId('arnoldIcon').firstChild.tagName).toEqual('svg');
+  });
+
+  it('should allow the user to click on the actionIcon', () => {
+    const onClick = jest.fn();
+
+    const { getByTestId } = render(
+      <TextField
+        __actionIconId="arnoldIcon"
+        actionIcon="phone"
+        actionIconOnClick={onClick}
+        data-testid="focusInput"
+        label="Hello"
+        id="myTestId"
+      />,
+    );
+
+    // The onClick event gets attached to the SVG child element, so make sure
+    // that's what we click on.
+    fireEvent.click(getByTestId('arnoldIcon').firstChild);
+
+    expect(onClick).toHaveBeenCalled();
+  });
+
   it('should forward refs', () => {
     const ref = createRef();
 


### PR DESCRIPTION
This introduces icons in TextFields, which will close #84 and also set groundwork for the ComboBox component being slowly built in #206. 

<img width="657" alt="Screenshot 2020-03-23 at 14 37 20" src="https://user-images.githubusercontent.com/376315/77327953-cf6c2a00-6d13-11ea-9ea2-1651450edf6a.png">

It introduces the concept of a "signifier icon" (one that communicates meaning) and an "action icon" (one you can click on to do stuff), with consistent placement inside the input. They're currently styled in the same way but that will change later, once the action icon actually has the ability to do something.

What I need help with:
- Making action icons actually be able do something. They should probably use a Button component with an Icon inside—I'm working on this in a separate PR but it's not quite ready yet. If we can easily pass an action callback to the icon and have that work in a sensible way here, that might be easier, and we can improve later.... or we may not need it to be a Button at all. I'm not sure yet, but would appreciate guidance/feedback!
- Clicking the signifier icon should move focus to the input.
- Tests aren't happy. 