### PR TITLE
fix: Improve Link behaviour

### DIFF
--- a/src/components/ui/Link/__snapshots__/index.test.js.snap
+++ b/src/components/ui/Link/__snapshots__/index.test.js.snap
@@ -13,23 +13,29 @@ exports[`Link should not output styles when unstyled is set 1`] = `
 
 exports[`Link should output Link styles 1`] = `
 .emotion-0 {
-  border-bottom: 2px solid #f5bbda;
   color: #cd2f83;
-  -webkit-text-decoration: none;
-  text-decoration: none;
+  -webkit-text-decoration-color: #f5bbda;
+  text-decoration-color: #f5bbda;
+  -webkit-text-decoration-thickness: 2px;
+  text-decoration-thickness: 2px;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-underline-offset: 0.25em;
   -webkit-transition: all 200ms ease-in-out;
   transition: all 200ms ease-in-out;
 }
 
 .emotion-0:hover {
-  border-color: #a0dee3;
   color: #0097a2;
+  -webkit-text-decoration-color: #a0dee3;
+  text-decoration-color: #a0dee3;
 }
 
 .emotion-0:focus {
-  border-color: transparent;
   box-shadow: #f5bbda 0 0 0 3px;
   outline: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 <div>

--- a/src/components/ui/Link/__snapshots__/index.test.js.snap
+++ b/src/components/ui/Link/__snapshots__/index.test.js.snap
@@ -18,8 +18,8 @@ exports[`Link should output Link styles 1`] = `
   text-decoration-color: #f5bbda;
   -webkit-text-decoration-thickness: 2px;
   text-decoration-thickness: 2px;
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
+  -webkit-text-decoration-style: underline;
+  text-decoration-style: underline;
   text-underline-offset: 0.25em;
   -webkit-transition: all 200ms ease-in-out;
   transition: all 200ms ease-in-out;

--- a/src/components/ui/Link/index.js
+++ b/src/components/ui/Link/index.js
@@ -46,13 +46,15 @@ const Link = (props) => {
       {children}
       {external && (
         <React.Fragment>
-          {' '}
           <Icon
             name="external-link"
             noMargin
             small
             strokeColor={theme.colors.neutral.grey600}
             title="External link"
+            css={css`
+              margin-left: 0.4rem;
+            `}
           />
         </React.Fragment>
       )}

--- a/src/components/ui/Link/index.js
+++ b/src/components/ui/Link/index.js
@@ -24,7 +24,7 @@ const Link = (props) => {
               color: ${theme.colors.state.interactiveText};
               text-decoration-color: ${theme.colors.state.interactive};
               text-decoration-thickness: 2px; 
-              text-decoration: underline;
+              text-decoration-style: underline;
               text-underline-offset: 0.25em;
               transition: all 200ms ease-in-out;
             }

--- a/src/components/ui/Link/index.js
+++ b/src/components/ui/Link/index.js
@@ -23,11 +23,10 @@ const Link = (props) => {
           : css`
               color: ${theme.colors.state.interactiveText};
               text-decoration-color: ${theme.colors.state.interactive};
-              text-decoration-thickness: 2px; 
+              text-decoration-thickness: 2px;
               text-decoration-style: underline;
               text-underline-offset: 0.25em;
               transition: all 200ms ease-in-out;
-            }
 
               &:hover {
                 color: ${theme.colors.state.hoverText};

--- a/src/components/ui/Link/index.js
+++ b/src/components/ui/Link/index.js
@@ -21,20 +21,23 @@ const Link = (props) => {
         unstyled
           ? undefined
           : css`
-              border-bottom: 2px solid ${theme.colors.state.interactive};
               color: ${theme.colors.state.interactiveText};
-              text-decoration: none;
+              text-decoration-color: ${theme.colors.state.interactive};
+              text-decoration-thickness: 2px; 
+              text-decoration: underline;
+              text-underline-offset: 0.25em; 
               transition: all 200ms ease-in-out;
+            }
 
               &:hover {
-                border-color: ${theme.colors.state.hover};
                 color: ${theme.colors.state.hoverText};
+                text-decoration-color: ${theme.colors.state.hover};
               }
 
               &:focus {
-                border-color: transparent;
                 box-shadow: ${theme.colors.state.interactive} 0 0 0 3px;
                 outline: none;
+                text-decoration: none;
               }
             `
       }
@@ -45,14 +48,7 @@ const Link = (props) => {
       {external && (
         <React.Fragment>
           {' '}
-          <Icon
-            name="external-link"
-            title="External link"
-            small
-            css={css`
-              margin: 0;
-            `}
-          />
+          <Icon name="external-link" title="External link" small noMargin />
         </React.Fragment>
       )}
     </LinkComponent>

--- a/src/components/ui/Link/index.js
+++ b/src/components/ui/Link/index.js
@@ -25,7 +25,7 @@ const Link = (props) => {
               text-decoration-color: ${theme.colors.state.interactive};
               text-decoration-thickness: 2px; 
               text-decoration: underline;
-              text-underline-offset: 0.25em; 
+              text-underline-offset: 0.25em;
               transition: all 200ms ease-in-out;
             }
 
@@ -48,7 +48,13 @@ const Link = (props) => {
       {external && (
         <React.Fragment>
           {' '}
-          <Icon name="external-link" title="External link" small noMargin />
+          <Icon
+            name="external-link"
+            noMargin
+            small
+            strokeColor={theme.colors.neutral.grey600}
+            title="External link"
+          />
         </React.Fragment>
       )}
     </LinkComponent>

--- a/src/components/ui/Link/index.js
+++ b/src/components/ui/Link/index.js
@@ -4,6 +4,7 @@ import React, { useContext } from 'react';
 
 import { NautilusLinkComponentContext } from '../../hoc/Nautilus/context';
 import Icon from '../Icon';
+import { toUnits } from '../../../styles';
 import { useTheme } from '../../../themes';
 
 const LinkTag = 'a';
@@ -53,7 +54,7 @@ const Link = (props) => {
             strokeColor={theme.colors.neutral.grey600}
             title="External link"
             css={css`
-              margin-left: 0.4rem;
+              margin-left: ${toUnits(theme.spacing.padding.xSmall)};
             `}
           />
         </React.Fragment>

--- a/src/components/ui/SkipLink/__snapshots__/index.test.js.snap
+++ b/src/components/ui/SkipLink/__snapshots__/index.test.js.snap
@@ -7,8 +7,8 @@ exports[`SkipLink should contain styles, including focus styles that reveal the 
   text-decoration-color: #f5bbda;
   -webkit-text-decoration-thickness: 2px;
   text-decoration-thickness: 2px;
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
+  -webkit-text-decoration-style: underline;
+  text-decoration-style: underline;
   text-underline-offset: 0.25em;
   -webkit-transition: all 200ms ease-in-out;
   transition: all 200ms ease-in-out;

--- a/src/components/ui/SkipLink/__snapshots__/index.test.js.snap
+++ b/src/components/ui/SkipLink/__snapshots__/index.test.js.snap
@@ -2,10 +2,14 @@
 
 exports[`SkipLink should contain styles, including focus styles that reveal the link 1`] = `
 .emotion-0 {
-  border-bottom: 2px solid #f5bbda;
   color: #cd2f83;
-  -webkit-text-decoration: none;
-  text-decoration: none;
+  -webkit-text-decoration-color: #f5bbda;
+  text-decoration-color: #f5bbda;
+  -webkit-text-decoration-thickness: 2px;
+  text-decoration-thickness: 2px;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-underline-offset: 0.25em;
   -webkit-transition: all 200ms ease-in-out;
   transition: all 200ms ease-in-out;
   border: 0;
@@ -23,14 +27,16 @@ exports[`SkipLink should contain styles, including focus styles that reveal the 
 }
 
 .emotion-0:hover {
-  border-color: #a0dee3;
   color: #0097a2;
+  -webkit-text-decoration-color: #a0dee3;
+  text-decoration-color: #a0dee3;
 }
 
 .emotion-0:focus {
-  border-color: transparent;
   box-shadow: #f5bbda 0 0 0 3px;
   outline: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .emotion-0:focus {


### PR DESCRIPTION
This fixes a couple of little things, namely links in paragraphs messing with line-heights (#218) and generally looking a bit awkward, and the external link indication being way too agressive (#217). It switches from using a border-bottom for the link to an _actual text decoration_, (who knew!) because it's a bit smarter that way.

**Before:**
<img width="564" alt="Screenshot 2020-04-03 at 18 32 05" src="https://user-images.githubusercontent.com/376315/78388771-7a64c980-75d9-11ea-9355-299e5f6b1105.png">

<img width="564" alt="Screenshot 2020-04-03 at 18 30 08" src="https://user-images.githubusercontent.com/376315/78388798-88b2e580-75d9-11ea-9988-deb40d5fc546.png">

**After:**
<img width="564" alt="Screenshot 2020-04-03 at 18 32 16" src="https://user-images.githubusercontent.com/376315/78388774-7afd6000-75d9-11ea-9e3e-9b2287698589.png">

<img width="564" alt="Screenshot 2020-04-03 at 18 31 54" src="https://user-images.githubusercontent.com/376315/78388801-89e41280-75d9-11ea-8cee-2ff670b93f1b.png">