### PR TITLE
fix: Fix link underlines in Blink browsers.

### DIFF
--- a/src/components/ui/Link/__snapshots__/index.test.js.snap
+++ b/src/components/ui/Link/__snapshots__/index.test.js.snap
@@ -14,25 +14,20 @@ exports[`Link should not output styles when unstyled is set 1`] = `
 exports[`Link should output Link styles 1`] = `
 .emotion-0 {
   color: #cd2f83;
-  -webkit-text-decoration-color: #f5bbda;
-  text-decoration-color: #f5bbda;
-  -webkit-text-decoration-thickness: 2px;
-  text-decoration-thickness: 2px;
-  -webkit-text-decoration-style: underline;
-  text-decoration-style: underline;
-  text-underline-offset: 0.25em;
+  box-shadow: 0 2px #f5bbda;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   -webkit-transition: all 200ms ease-in-out;
   transition: all 200ms ease-in-out;
 }
 
 .emotion-0:hover {
+  box-shadow: 0 2px #a0dee3;
   color: #0097a2;
-  -webkit-text-decoration-color: #a0dee3;
-  text-decoration-color: #a0dee3;
 }
 
 .emotion-0:focus {
-  box-shadow: #f5bbda 0 0 0 3px;
+  box-shadow: 0 0 0 3px #f5bbda;
   outline: none;
   -webkit-text-decoration: none;
   text-decoration: none;

--- a/src/components/ui/Link/index.js
+++ b/src/components/ui/Link/index.js
@@ -23,19 +23,17 @@ const Link = (props) => {
           ? undefined
           : css`
               color: ${theme.colors.state.interactiveText};
-              text-decoration-color: ${theme.colors.state.interactive};
-              text-decoration-thickness: 2px;
-              text-decoration-style: underline;
-              text-underline-offset: 0.25em;
+              box-shadow: 0 2px ${theme.colors.state.interactive};
+              text-decoration: none;
               transition: all 200ms ease-in-out;
 
               &:hover {
+                box-shadow: 0 2px ${theme.colors.state.hover};
                 color: ${theme.colors.state.hoverText};
-                text-decoration-color: ${theme.colors.state.hover};
               }
 
               &:focus {
-                box-shadow: ${theme.colors.state.interactive} 0 0 0 3px;
+                box-shadow: 0 0 0 3px ${theme.colors.state.interactive};
                 outline: none;
                 text-decoration: none;
               }

--- a/src/components/ui/SkipLink/__snapshots__/index.test.js.snap
+++ b/src/components/ui/SkipLink/__snapshots__/index.test.js.snap
@@ -3,13 +3,9 @@
 exports[`SkipLink should contain styles, including focus styles that reveal the link 1`] = `
 .emotion-0 {
   color: #cd2f83;
-  -webkit-text-decoration-color: #f5bbda;
-  text-decoration-color: #f5bbda;
-  -webkit-text-decoration-thickness: 2px;
-  text-decoration-thickness: 2px;
-  -webkit-text-decoration-style: underline;
-  text-decoration-style: underline;
-  text-underline-offset: 0.25em;
+  box-shadow: 0 2px #f5bbda;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   -webkit-transition: all 200ms ease-in-out;
   transition: all 200ms ease-in-out;
   border: 0;
@@ -27,13 +23,12 @@ exports[`SkipLink should contain styles, including focus styles that reveal the 
 }
 
 .emotion-0:hover {
+  box-shadow: 0 2px #a0dee3;
   color: #0097a2;
-  -webkit-text-decoration-color: #a0dee3;
-  text-decoration-color: #a0dee3;
 }
 
 .emotion-0:focus {
-  box-shadow: #f5bbda 0 0 0 3px;
+  box-shadow: 0 0 0 3px #f5bbda;
   outline: none;
   -webkit-text-decoration: none;
   text-decoration: none;


### PR DESCRIPTION
Apparently there's no support for text-decoration fanciness in Chrome or Edge, so let's revert back to using box-shadow, at least until support improves.

Before:
<img width="571" alt="Screenshot 2020-04-10 at 14 11 51" src="https://user-images.githubusercontent.com/376315/78993268-420f3f00-7b35-11ea-8abd-bc7e99dd0bb1.png">

After:
<img width="571" alt="Screenshot 2020-04-10 at 14 11 32" src="https://user-images.githubusercontent.com/376315/78993275-476c8980-7b35-11ea-9c61-66a600958029.png">
