### PR TITLE
fix: Hide tab headings.

### DIFF
--- a/src/components/ui/Tabs/Tab.js
+++ b/src/components/ui/Tabs/Tab.js
@@ -2,7 +2,8 @@ import { css } from '@emotion/core';
 import PropTypes from 'prop-types';
 import React, { forwardRef } from 'react';
 
-import Heading from '../Heading';
+import Paragraph from '../Paragraph';
+import VisuallyHidden from '../VisuallyHidden';
 import { focusStyle } from '../../../styles';
 import { useTheme } from '../../../themes';
 
@@ -36,9 +37,9 @@ const Tab = forwardRef((props, ref) => {
       tabIndex="-1"
       {...otherProps}
     >
-      <Heading level={4} unstyled>
-        {label}
-      </Heading>
+      <VisuallyHidden>
+        <Paragraph unstyled>{label}</Paragraph>
+      </VisuallyHidden>
 
       {children}
     </section>

--- a/src/components/ui/Tabs/Tab.js
+++ b/src/components/ui/Tabs/Tab.js
@@ -2,8 +2,6 @@ import { css } from '@emotion/core';
 import PropTypes from 'prop-types';
 import React, { forwardRef } from 'react';
 
-import Paragraph from '../Paragraph';
-import VisuallyHidden from '../VisuallyHidden';
 import { focusStyle } from '../../../styles';
 import { useTheme } from '../../../themes';
 
@@ -37,10 +35,6 @@ const Tab = forwardRef((props, ref) => {
       tabIndex="-1"
       {...otherProps}
     >
-      <VisuallyHidden>
-        <Paragraph unstyled>{label}</Paragraph>
-      </VisuallyHidden>
-
       {children}
     </section>
   );

--- a/src/components/ui/Tabs/Tab.test.js
+++ b/src/components/ui/Tabs/Tab.test.js
@@ -22,14 +22,14 @@ describe('Tabs.Tab', () => {
     expect(container.firstChild.tagName).toEqual('SECTION');
   });
 
-  it('should render the label inside an h4', () => {
+  it('should render the label inside a <span>', () => {
     const { container } = render(
       <Tabs.Tab label="About">
         <Paragraph>Puppies are cute.</Paragraph>
       </Tabs.Tab>,
     );
 
-    expect(container.firstChild.children[0].tagName).toEqual('H4');
+    expect(container.firstChild.children[0].tagName).toEqual('SPAN');
   });
 
   it('should render the children as-provided', () => {

--- a/src/components/ui/Tabs/Tab.test.js
+++ b/src/components/ui/Tabs/Tab.test.js
@@ -22,24 +22,14 @@ describe('Tabs.Tab', () => {
     expect(container.firstChild.tagName).toEqual('SECTION');
   });
 
-  it('should render the label inside a <span>', () => {
+  it('should render the children as provided', () => {
     const { container } = render(
       <Tabs.Tab label="About">
         <Paragraph>Puppies are cute.</Paragraph>
       </Tabs.Tab>,
     );
 
-    expect(container.firstChild.children[0].tagName).toEqual('SPAN');
-  });
-
-  it('should render the children as-provided', () => {
-    const { container } = render(
-      <Tabs.Tab label="About">
-        <Paragraph>Puppies are cute.</Paragraph>
-      </Tabs.Tab>,
-    );
-
-    expect(container.firstChild.children[1].tagName).toEqual('P');
+    expect(container.firstChild.children[0].tagName).toEqual('P');
   });
 
   it('should render styles for a Tabs.Tab', () => {

--- a/src/components/ui/Tabs/__snapshots__/Tab.test.js.snap
+++ b/src/components/ui/Tabs/__snapshots__/Tab.test.js.snap
@@ -2,6 +2,21 @@
 
 exports[`Tabs.Tab should not render styles when unstyled prop is set 1`] = `
 .emotion-1 {
+  border: 0;
+  -webkit-clip-path: rect(0 0 0 0);
+  clip-path: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.emotion-2 {
   color: #3b3f45;
   margin: 0;
   margin: 0 0 3.2rem;
@@ -13,17 +28,21 @@ exports[`Tabs.Tab should not render styles when unstyled prop is set 1`] = `
 
 <div>
   <section
-    class="emotion-2"
+    class="emotion-3"
     role="tabpanel"
     tabindex="-1"
   >
-    <h4
-      class="emotion-0"
+    <span
+      class="emotion-1"
     >
-      About
-    </h4>
+      <p
+        class="Nautilus-Paragraph emotion-0"
+      >
+        About
+      </p>
+    </span>
     <p
-      class="Nautilus-Paragraph emotion-1"
+      class="Nautilus-Paragraph emotion-2"
     >
       Puppies are cute.
     </p>
@@ -32,16 +51,31 @@ exports[`Tabs.Tab should not render styles when unstyled prop is set 1`] = `
 `;
 
 exports[`Tabs.Tab should render styles for a Tabs.Tab 1`] = `
-.emotion-2 {
+.emotion-3 {
   display: none;
 }
 
-.emotion-2:focus {
+.emotion-3:focus {
   box-shadow: 0 0 0 0.4rem #f5bbda;
   outline: 0;
 }
 
 .emotion-1 {
+  border: 0;
+  -webkit-clip-path: rect(0 0 0 0);
+  clip-path: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.emotion-2 {
   color: #3b3f45;
   margin: 0;
   margin: 0 0 3.2rem;
@@ -53,17 +87,21 @@ exports[`Tabs.Tab should render styles for a Tabs.Tab 1`] = `
 
 <div>
   <section
-    class="emotion-2"
+    class="emotion-3"
     role="tabpanel"
     tabindex="-1"
   >
-    <h4
-      class="emotion-0"
+    <span
+      class="emotion-1"
     >
-      About
-    </h4>
+      <p
+        class="Nautilus-Paragraph emotion-0"
+      >
+        About
+      </p>
+    </span>
     <p
-      class="Nautilus-Paragraph emotion-1"
+      class="Nautilus-Paragraph emotion-2"
     >
       Puppies are cute.
     </p>

--- a/src/components/ui/Tabs/__snapshots__/Tab.test.js.snap
+++ b/src/components/ui/Tabs/__snapshots__/Tab.test.js.snap
@@ -1,22 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Tabs.Tab should not render styles when unstyled prop is set 1`] = `
-.emotion-1 {
-  border: 0;
-  -webkit-clip-path: rect(0 0 0 0);
-  clip-path: rect(0 0 0 0);
-  -webkit-clip-path: inset(50%);
-  clip-path: inset(50%);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
-}
-
-.emotion-2 {
+.emotion-0 {
   color: #3b3f45;
   margin: 0;
   margin: 0 0 3.2rem;
@@ -28,21 +13,12 @@ exports[`Tabs.Tab should not render styles when unstyled prop is set 1`] = `
 
 <div>
   <section
-    class="emotion-3"
+    class="emotion-1"
     role="tabpanel"
     tabindex="-1"
   >
-    <span
-      class="emotion-1"
-    >
-      <p
-        class="Nautilus-Paragraph emotion-0"
-      >
-        About
-      </p>
-    </span>
     <p
-      class="Nautilus-Paragraph emotion-2"
+      class="Nautilus-Paragraph emotion-0"
     >
       Puppies are cute.
     </p>
@@ -51,31 +27,16 @@ exports[`Tabs.Tab should not render styles when unstyled prop is set 1`] = `
 `;
 
 exports[`Tabs.Tab should render styles for a Tabs.Tab 1`] = `
-.emotion-3 {
+.emotion-1 {
   display: none;
 }
 
-.emotion-3:focus {
+.emotion-1:focus {
   box-shadow: 0 0 0 0.4rem #f5bbda;
   outline: 0;
 }
 
-.emotion-1 {
-  border: 0;
-  -webkit-clip-path: rect(0 0 0 0);
-  clip-path: rect(0 0 0 0);
-  -webkit-clip-path: inset(50%);
-  clip-path: inset(50%);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
-}
-
-.emotion-2 {
+.emotion-0 {
   color: #3b3f45;
   margin: 0;
   margin: 0 0 3.2rem;
@@ -87,21 +48,12 @@ exports[`Tabs.Tab should render styles for a Tabs.Tab 1`] = `
 
 <div>
   <section
-    class="emotion-3"
+    class="emotion-1"
     role="tabpanel"
     tabindex="-1"
   >
-    <span
-      class="emotion-1"
-    >
-      <p
-        class="Nautilus-Paragraph emotion-0"
-      >
-        About
-      </p>
-    </span>
     <p
-      class="Nautilus-Paragraph emotion-2"
+      class="Nautilus-Paragraph emotion-0"
     >
       Puppies are cute.
     </p>

--- a/src/components/ui/Tabs/__snapshots__/index.test.js.snap
+++ b/src/components/ui/Tabs/__snapshots__/index.test.js.snap
@@ -51,12 +51,27 @@ exports[`Tabs should not render styles when unstyled prop is set 1`] = `
   border-bottom: 3px solid;
 }
 
-.emotion-4:focus {
+.emotion-5:focus {
   box-shadow: 0 0 0 0.4rem #f5bbda;
   outline: 0;
 }
 
 .emotion-3 {
+  border: 0;
+  -webkit-clip-path: rect(0 0 0 0);
+  clip-path: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.emotion-4 {
   color: #3b3f45;
   margin: 0;
   margin: 0 0 3.2rem;
@@ -88,19 +103,23 @@ exports[`Tabs should not render styles when unstyled prop is set 1`] = `
   </ul>
   <section
     aria-labelledby="myTabSet-tab-0"
-    class="emotion-4"
+    class="emotion-5"
     data-testid="firstTabSection"
     id="myTabSet-section-0"
     role="tabpanel"
     tabindex="-1"
   >
-    <h4
-      class="emotion-2"
+    <span
+      class="emotion-3"
     >
-      About
-    </h4>
+      <p
+        class="Nautilus-Paragraph emotion-2"
+      >
+        About
+      </p>
+    </span>
     <p
-      class="Nautilus-Paragraph emotion-3"
+      class="Nautilus-Paragraph emotion-4"
     >
       Puppies are cute.
     </p>
@@ -187,12 +206,27 @@ exports[`Tabs should render styles for Tabs 1`] = `
   outline: 0;
 }
 
-.emotion-6:focus {
+.emotion-7:focus {
   box-shadow: 0 0 0 0.4rem #f5bbda;
   outline: 0;
 }
 
 .emotion-5 {
+  border: 0;
+  -webkit-clip-path: rect(0 0 0 0);
+  clip-path: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.emotion-6 {
   color: #3b3f45;
   margin: 0;
   margin: 0 0 3.2rem;
@@ -202,11 +236,11 @@ exports[`Tabs should render styles for Tabs 1`] = `
   line-height: 1.5555555555555556;
 }
 
-.emotion-9 {
+.emotion-11 {
   display: none;
 }
 
-.emotion-9:focus {
+.emotion-11:focus {
   box-shadow: 0 0 0 0.4rem #f5bbda;
   outline: 0;
 }
@@ -263,57 +297,69 @@ exports[`Tabs should render styles for Tabs 1`] = `
   </ul>
   <section
     aria-labelledby="myTabSet-tab-0"
-    class="emotion-6"
+    class="emotion-7"
     data-testid="firstTabSection"
     id="myTabSet-section-0"
     role="tabpanel"
     tabindex="-1"
   >
-    <h4
-      class="emotion-4"
+    <span
+      class="emotion-5"
     >
-      About
-    </h4>
+      <p
+        class="Nautilus-Paragraph emotion-4"
+      >
+        About
+      </p>
+    </span>
     <p
-      class="Nautilus-Paragraph emotion-5"
+      class="Nautilus-Paragraph emotion-6"
     >
       Puppies are cute.
     </p>
   </section>
   <section
     aria-labelledby="myTabSet-tab-1"
-    class="emotion-9"
+    class="emotion-11"
     data-testid="secondTabSection"
     id="myTabSet-section-1"
     role="tabpanel"
     tabindex="-1"
   >
-    <h4
-      class="emotion-4"
+    <span
+      class="emotion-5"
     >
-      History
-    </h4>
+      <p
+        class="Nautilus-Paragraph emotion-4"
+      >
+        History
+      </p>
+    </span>
     <p
-      class="Nautilus-Paragraph emotion-5"
+      class="Nautilus-Paragraph emotion-6"
     >
       Puppies have already been cute.
     </p>
   </section>
   <section
     aria-labelledby="myTabSet-tab-2"
-    class="emotion-9"
+    class="emotion-11"
     data-testid="thirdTabSection"
     id="myTabSet-section-2"
     role="tabpanel"
     tabindex="-1"
   >
-    <h4
-      class="emotion-4"
+    <span
+      class="emotion-5"
     >
-      Other
-    </h4>
+      <p
+        class="Nautilus-Paragraph emotion-4"
+      >
+        Other
+      </p>
+    </span>
     <p
-      class="Nautilus-Paragraph emotion-5"
+      class="Nautilus-Paragraph emotion-6"
     >
       I have run out of things to say in this test.
     </p>
@@ -355,12 +401,27 @@ exports[`Tabs shouldn't have a margin when \`noMargin\` is true 1`] = `
   border-bottom: 3px solid;
 }
 
-.emotion-4:focus {
+.emotion-5:focus {
   box-shadow: 0 0 0 0.4rem #f5bbda;
   outline: 0;
 }
 
 .emotion-3 {
+  border: 0;
+  -webkit-clip-path: rect(0 0 0 0);
+  clip-path: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.emotion-4 {
   color: #3b3f45;
   margin: 0;
   margin: 0 0 3.2rem;
@@ -408,19 +469,23 @@ exports[`Tabs shouldn't have a margin when \`noMargin\` is true 1`] = `
   </ul>
   <section
     aria-labelledby="myTabSet-tab-0"
-    class="emotion-4"
+    class="emotion-5"
     data-testid="firstTabSection"
     id="myTabSet-section-0"
     role="tabpanel"
     tabindex="-1"
   >
-    <h4
-      class="emotion-2"
+    <span
+      class="emotion-3"
     >
-      About
-    </h4>
+      <p
+        class="Nautilus-Paragraph emotion-2"
+      >
+        About
+      </p>
+    </span>
     <p
-      class="Nautilus-Paragraph emotion-3"
+      class="Nautilus-Paragraph emotion-4"
     >
       Puppies are cute.
     </p>

--- a/src/components/ui/Tabs/__snapshots__/index.test.js.snap
+++ b/src/components/ui/Tabs/__snapshots__/index.test.js.snap
@@ -51,27 +51,12 @@ exports[`Tabs should not render styles when unstyled prop is set 1`] = `
   border-bottom: 3px solid;
 }
 
-.emotion-5:focus {
+.emotion-3:focus {
   box-shadow: 0 0 0 0.4rem #f5bbda;
   outline: 0;
 }
 
-.emotion-3 {
-  border: 0;
-  -webkit-clip-path: rect(0 0 0 0);
-  clip-path: rect(0 0 0 0);
-  -webkit-clip-path: inset(50%);
-  clip-path: inset(50%);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
-}
-
-.emotion-4 {
+.emotion-2 {
   color: #3b3f45;
   margin: 0;
   margin: 0 0 3.2rem;
@@ -103,23 +88,14 @@ exports[`Tabs should not render styles when unstyled prop is set 1`] = `
   </ul>
   <section
     aria-labelledby="myTabSet-tab-0"
-    class="emotion-5"
+    class="emotion-3"
     data-testid="firstTabSection"
     id="myTabSet-section-0"
     role="tabpanel"
     tabindex="-1"
   >
-    <span
-      class="emotion-3"
-    >
-      <p
-        class="Nautilus-Paragraph emotion-2"
-      >
-        About
-      </p>
-    </span>
     <p
-      class="Nautilus-Paragraph emotion-4"
+      class="Nautilus-Paragraph emotion-2"
     >
       Puppies are cute.
     </p>
@@ -206,27 +182,12 @@ exports[`Tabs should render styles for Tabs 1`] = `
   outline: 0;
 }
 
-.emotion-7:focus {
+.emotion-5:focus {
   box-shadow: 0 0 0 0.4rem #f5bbda;
   outline: 0;
 }
 
-.emotion-5 {
-  border: 0;
-  -webkit-clip-path: rect(0 0 0 0);
-  clip-path: rect(0 0 0 0);
-  -webkit-clip-path: inset(50%);
-  clip-path: inset(50%);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
-}
-
-.emotion-6 {
+.emotion-4 {
   color: #3b3f45;
   margin: 0;
   margin: 0 0 3.2rem;
@@ -236,11 +197,11 @@ exports[`Tabs should render styles for Tabs 1`] = `
   line-height: 1.5555555555555556;
 }
 
-.emotion-11 {
+.emotion-7 {
   display: none;
 }
 
-.emotion-11:focus {
+.emotion-7:focus {
   box-shadow: 0 0 0 0.4rem #f5bbda;
   outline: 0;
 }
@@ -297,69 +258,42 @@ exports[`Tabs should render styles for Tabs 1`] = `
   </ul>
   <section
     aria-labelledby="myTabSet-tab-0"
-    class="emotion-7"
+    class="emotion-5"
     data-testid="firstTabSection"
     id="myTabSet-section-0"
     role="tabpanel"
     tabindex="-1"
   >
-    <span
-      class="emotion-5"
-    >
-      <p
-        class="Nautilus-Paragraph emotion-4"
-      >
-        About
-      </p>
-    </span>
     <p
-      class="Nautilus-Paragraph emotion-6"
+      class="Nautilus-Paragraph emotion-4"
     >
       Puppies are cute.
     </p>
   </section>
   <section
     aria-labelledby="myTabSet-tab-1"
-    class="emotion-11"
+    class="emotion-7"
     data-testid="secondTabSection"
     id="myTabSet-section-1"
     role="tabpanel"
     tabindex="-1"
   >
-    <span
-      class="emotion-5"
-    >
-      <p
-        class="Nautilus-Paragraph emotion-4"
-      >
-        History
-      </p>
-    </span>
     <p
-      class="Nautilus-Paragraph emotion-6"
+      class="Nautilus-Paragraph emotion-4"
     >
       Puppies have already been cute.
     </p>
   </section>
   <section
     aria-labelledby="myTabSet-tab-2"
-    class="emotion-11"
+    class="emotion-7"
     data-testid="thirdTabSection"
     id="myTabSet-section-2"
     role="tabpanel"
     tabindex="-1"
   >
-    <span
-      class="emotion-5"
-    >
-      <p
-        class="Nautilus-Paragraph emotion-4"
-      >
-        Other
-      </p>
-    </span>
     <p
-      class="Nautilus-Paragraph emotion-6"
+      class="Nautilus-Paragraph emotion-4"
     >
       I have run out of things to say in this test.
     </p>
@@ -401,27 +335,12 @@ exports[`Tabs shouldn't have a margin when \`noMargin\` is true 1`] = `
   border-bottom: 3px solid;
 }
 
-.emotion-5:focus {
+.emotion-3:focus {
   box-shadow: 0 0 0 0.4rem #f5bbda;
   outline: 0;
 }
 
-.emotion-3 {
-  border: 0;
-  -webkit-clip-path: rect(0 0 0 0);
-  clip-path: rect(0 0 0 0);
-  -webkit-clip-path: inset(50%);
-  clip-path: inset(50%);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
-}
-
-.emotion-4 {
+.emotion-2 {
   color: #3b3f45;
   margin: 0;
   margin: 0 0 3.2rem;
@@ -469,23 +388,14 @@ exports[`Tabs shouldn't have a margin when \`noMargin\` is true 1`] = `
   </ul>
   <section
     aria-labelledby="myTabSet-tab-0"
-    class="emotion-5"
+    class="emotion-3"
     data-testid="firstTabSection"
     id="myTabSet-section-0"
     role="tabpanel"
     tabindex="-1"
   >
-    <span
-      class="emotion-3"
-    >
-      <p
-        class="Nautilus-Paragraph emotion-2"
-      >
-        About
-      </p>
-    </span>
     <p
-      class="Nautilus-Paragraph emotion-4"
+      class="Nautilus-Paragraph emotion-2"
     >
       Puppies are cute.
     </p>


### PR DESCRIPTION
Visually, these don't make sense to show since the tab itself already provides this context. My suspicion is that we'd always intended to hide these, but perhaps didn't originally for lack of a VisuallyHidden component? Maybe?

Before:
<img width="699" alt="Screenshot 2020-06-01 at 21 40 24" src="https://user-images.githubusercontent.com/376315/83452415-93aaba80-a450-11ea-80cd-b0110c015972.png">

After:
<img width="699" alt="Screenshot 2020-06-01 at 21 40 40" src="https://user-images.githubusercontent.com/376315/83452418-94dbe780-a450-11ea-846a-4defa6d60767.png">

We're also switching it from a heading to a tab to ensure consistent heading hierarchy. If we wanted to stick with headings, I might recommend opting for something higher, like an h2, which is more likely to work with the page hierarchy, or pass a prop to declare the heading level. I could see the value in showing these as headings, so I'm not sure about the Paragraph approach here—maybe instead we should make them h1s or h2s by default, but allow users to pass through a different heading level if needed?