### PR TITLE
feat: Checkbox

### DIFF
--- a/src/components/ui/Checkbox/README.md
+++ b/src/components/ui/Checkbox/README.md
@@ -1,0 +1,30 @@
+A Checkbox allows users to...
+
+```jsx
+<Checkbox checked>Lions</Checkbox>
+<Checkbox>Tigers</Checkbox>
+<Checkbox>Bears</Checkbox>
+<Checkbox checked>Oh my!</Checkbox>
+```
+
+## Usage
+
+Use this component when users need to select a single item from a list of three or more options.
+
+Don't use this component for:
+
+- Choosing between. Use a `Radio` or `Toggle` instead.
+- Selecting from a long list of items. Use a `ComboBox` instead.
+- Entering a custom text value. Use a `TextField` instead.
+
+## Appearance
+
+## Interaction
+
+## Voice & Tone
+
+Follow the `TextField` [guidelines](../TextField) for voice & tone. Additionally:
+
+- Make sure list items aren’t wider than the text field. If an item is too wide, it will span two lines, which looks awkward and can be hard to parse. Keep things succinct.
+
+## Accessibility

--- a/src/components/ui/Checkbox/index.js
+++ b/src/components/ui/Checkbox/index.js
@@ -3,11 +3,11 @@ import { css } from '@emotion/core';
 import shortid from 'shortid';
 import PropTypes from 'prop-types';
 
-import { interfaceUI } from '../../../styles';
+import { interfaceUI, toUnits } from '../../../styles';
 import { useTheme } from '../../../themes';
 
 export const Checkbox = forwardRef((props, ref) => {
-  const { children, id, ...otherProps } = props;
+  const { children, id, noMargin, ...otherProps } = props;
   const [generatedId] = useState(shortid.generate());
   const inputId = useMemo(() => {
     return id || generatedId;
@@ -17,8 +17,13 @@ export const Checkbox = forwardRef((props, ref) => {
   return (
     <div
       css={css`
-        margin-bottom: 0.8rem;
         position: relative;
+
+        /* Set external margins */
+        ${!noMargin &&
+          css`
+            margin-bottom: ${toUnits(theme.spacing.margin.xxSmall)};
+          `}
       `}
     >
       <input

--- a/src/components/ui/Checkbox/index.js
+++ b/src/components/ui/Checkbox/index.js
@@ -1,0 +1,147 @@
+import React, { forwardRef, useMemo, useState } from 'react';
+import { css } from '@emotion/core';
+import shortid from 'shortid';
+import PropTypes from 'prop-types';
+
+import { interfaceUI } from '../../../styles';
+import { useTheme } from '../../../themes';
+
+export const Checkbox = forwardRef((props, ref) => {
+  const { children, id, ...otherProps } = props;
+  const [generatedId] = useState(shortid.generate());
+  const inputId = useMemo(() => {
+    return id || generatedId;
+  }, [generatedId, id]);
+  const theme = useTheme();
+
+  return (
+    <div
+      css={css`
+        margin-bottom: 0.8rem;
+        position: relative;
+      `}
+    >
+      <input
+        id={inputId}
+        type="checkbox"
+        ref={ref}
+        css={css`
+          position: absolute;
+          z-index: 1;
+          width: 44px;
+          height: 44px;
+          margin: 0;
+          opacity: 0;
+
+          &:checked + label {
+            color: ${theme.colors.text.dark};
+          }
+
+          /* Hide the checkmark by default. */
+          & + label::after {
+            content: none;
+          }
+
+          /*Unhide the checkmark on the checked state*/
+          &:checked + label::after {
+            content: '';
+          }
+
+          &:focus + label {
+            outline: 0.2rem solid ${theme.colors.accent.primaryLight};
+            outline-offset: 0.4rem;
+            padding-right: 0.8rem;
+          }
+        `}
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        {...otherProps}
+      />
+      <label
+        htmlFor={inputId}
+        css={css`
+          ${interfaceUI.small(theme)};
+          color: ${theme.colors.text.default};
+          position: relative;
+          padding-left: 3.2rem;
+
+          &::before,
+          &::after {
+            position: absolute;
+          }
+
+          /*Outer-box*/
+          &::before {
+            border: 2px solid ${theme.colors.neutral.black};
+            background: ${theme.colors.neutral.white};
+            content: '';
+            display: inline-block;
+            height: 2rem;
+            width: 2rem;
+            top: -1px;
+            left: 0;
+          }
+
+          /*Checkmark*/
+          &::after {
+            left: 4px;
+            top: 5px;
+            content: '';
+            display: inline-block;
+            height: 6px;
+            width: 14px;
+            border-left: 3px solid ${theme.colors.accent.secondary};
+            border-bottom: 3px solid ${theme.colors.accent.secondary};
+            transform: rotate(-50deg);
+          }
+        `}
+      >
+        {children}
+      </label>
+    </div>
+  );
+});
+
+Checkbox.defaultProps = {
+  children: undefined,
+  disabled: false,
+  error: undefined,
+  hint: undefined,
+  id: undefined,
+  labelId: undefined,
+  noMargin: false,
+  onBlur: undefined,
+  onChange: undefined,
+  onFocus: undefined,
+  unstyled: false,
+};
+
+Checkbox.propTypes = {
+  /** @ignore */
+  children: PropTypes.node,
+  /** @ignore */
+  onBlur: PropTypes.func,
+  /** @ignore */
+  onFocus: PropTypes.func,
+  /** Disables this input; this applies a disabled style and disables user input/interaction with this element. This is useful if you have inputs that are conditionally allowed based on other states in your UI. */
+  disabled: PropTypes.bool,
+  /** An error message (either a simple string or a component) used to output an error message related to this component's value. If provided, an `aria-errormessage` will be set on the input component that will tell users of assistive technology the error message relates to this input. */
+  error: PropTypes.node,
+  /** HTML `id` attribute of the `input` element. Used for both the input's `id` attribute and the `<label>` `for` attribute. */
+  id: PropTypes.string,
+  /** Additional context to help users understand the purpose of the input. */
+  hint: PropTypes.node,
+  /** Visible text that serves to introduce the input. */
+  label: PropTypes.node.isRequired,
+  /** HTML `id` attribute for the `<label>` tag used to label the text input component. */
+  labelId: PropTypes.string,
+  /** Remove any outer margins from component. */
+  noMargin: PropTypes.bool,
+  /** `onChange` handler for the `TextField` component. */
+  onChange: PropTypes.func,
+  /* @ignore Don't output any CSS styles. */
+  unstyled: PropTypes.bool,
+};
+
+export const { defaultProps, propTypes } = Checkbox;
+
+export default Checkbox;

--- a/src/components/ui/Checkbox/index.js
+++ b/src/components/ui/Checkbox/index.js
@@ -7,7 +7,7 @@ import { focusStyle, interfaceUI, toUnits } from '../../../styles';
 import { useTheme } from '../../../themes';
 
 export const Checkbox = forwardRef((props, ref) => {
-  const { children, id, noMargin, ...otherProps } = props;
+  const { children, id, noMargin, unstyled, ...otherProps } = props;
   const [generatedId] = useState(shortid.generate());
   const inputId = useMemo(() => {
     return id || generatedId;
@@ -16,89 +16,101 @@ export const Checkbox = forwardRef((props, ref) => {
 
   return (
     <div
-      css={css`
-        position: relative;
+      css={
+        unstyled
+          ? undefined
+          : css`
+              position: relative;
 
-        /* Set external margins */
-        ${!noMargin &&
-          css`
-            margin-bottom: ${toUnits(theme.spacing.margin.xxSmall)};
-          `}
-      `}
+              /* Set external margins */
+              ${!noMargin &&
+                css`
+                  margin-bottom: ${toUnits(theme.spacing.margin.xxSmall)};
+                `}
+            `
+      }
     >
       <input
         id={inputId}
         type="checkbox"
         ref={ref}
-        css={css`
-          position: absolute;
-          z-index: 1;
-          width: 44px;
-          height: 44px;
-          margin: 0;
-          opacity: 0;
+        css={
+          unstyled
+            ? undefined
+            : css`
+                position: absolute;
+                z-index: 1;
+                width: 44px;
+                height: 44px;
+                margin: 0;
+                opacity: 0;
 
-          &:checked + label {
-            color: ${theme.colors.text.dark};
-          }
+                &:checked + label {
+                  color: ${theme.colors.text.dark};
+                }
 
-          /* Hide the checkmark by default. */
-          & + label::after {
-            content: none;
-          }
+                /* Hide the checkmark by default. */
+                & + label::after {
+                  content: none;
+                }
 
-          /*Unhide the checkmark on the checked state*/
-          &:checked + label::after {
-            content: '';
-          }
+                /*Unhide the checkmark on the checked state*/
+                &:checked + label::after {
+                  content: '';
+                }
 
-          &:focus + label {
-            ${focusStyle.outline(theme)};
-            padding-right: ${toUnits(theme.spacing.margin.xxSmall)};
-            padding-bottom: 0.2rem;
-          }
-        `}
+                &:focus + label {
+                  ${focusStyle.outline(theme)};
+                  padding-right: ${toUnits(theme.spacing.margin.xxSmall)};
+                  padding-bottom: 0.2rem;
+                }
+              `
+        }
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...otherProps}
       />
       <label
         htmlFor={inputId}
-        css={css`
-          ${interfaceUI.small(theme)};
-          color: ${theme.colors.text.default};
-          position: relative;
-          padding-left: 3.2rem;
+        css={
+          unstyled
+            ? undefined
+            : css`
+                ${interfaceUI.small(theme)};
+                color: ${theme.colors.text.default};
+                position: relative;
+                padding-left: 3.2rem;
 
-          &::before,
-          &::after {
-            position: absolute;
-          }
+                &::before,
+                &::after {
+                  position: absolute;
+                }
 
-          /*Outer-box*/
-          &::before {
-            border: 2px solid ${theme.colors.neutral.black};
-            background: ${theme.colors.neutral.white};
-            content: '';
-            display: inline-block;
-            height: 2rem;
-            width: 2rem;
-            top: -1px;
-            left: 0;
-          }
+                /*Outer-box*/
+                &::before {
+                  border: 2px solid ${theme.colors.neutral.black};
+                  background: ${theme.colors.neutral.white};
+                  content: '';
+                  display: inline-block;
+                  height: 2rem;
+                  width: 2rem;
+                  top: -1px;
+                  left: 0;
+                }
 
-          /*Checkmark*/
-          &::after {
-            left: 4px;
-            top: 5px;
-            content: '';
-            display: inline-block;
-            height: 6px;
-            width: 14px;
-            border-left: 3px solid ${theme.colors.accent.secondary};
-            border-bottom: 3px solid ${theme.colors.accent.secondary};
-            transform: rotate(-50deg);
-          }
-        `}
+                /*Checkmark*/
+                &::after {
+                  left: 4px;
+                  top: 5px;
+                  content: '';
+                  display: inline-block;
+                  height: 6px;
+                  width: 14px;
+                  border-left: 3px solid ${theme.colors.accent.secondary};
+                  border-bottom: 3px solid ${theme.colors.accent.secondary};
+                  transform: rotate(-50deg);
+                }
+              `
+        }
       >
         {children}
       </label>

--- a/src/components/ui/Checkbox/index.js
+++ b/src/components/ui/Checkbox/index.js
@@ -3,7 +3,7 @@ import { css } from '@emotion/core';
 import shortid from 'shortid';
 import PropTypes from 'prop-types';
 
-import { interfaceUI, toUnits } from '../../../styles';
+import { focusStyle, interfaceUI, toUnits } from '../../../styles';
 import { useTheme } from '../../../themes';
 
 export const Checkbox = forwardRef((props, ref) => {
@@ -53,9 +53,9 @@ export const Checkbox = forwardRef((props, ref) => {
           }
 
           &:focus + label {
-            outline: 0.2rem solid ${theme.colors.accent.primaryLight};
-            outline-offset: 0.4rem;
-            padding-right: 0.8rem;
+            ${focusStyle.outline(theme)};
+            padding-right: ${toUnits(theme.spacing.margin.xxSmall)};
+            padding-bottom: 0.2rem;
           }
         `}
         // eslint-disable-next-line react/jsx-props-no-spreading


### PR DESCRIPTION
<img width="171" alt="Screenshot 2020-06-20 at 23 38 34" src="https://user-images.githubusercontent.com/376315/85212892-2b644000-b34f-11ea-93d5-e8b00eae5d02.png">

I've extracted this from octopusthink.com, where we're using it for the contact form. Accordingly, some of the bits & pieces aren't quite working properly anymore:

- there doesn't seem to be a way to check a checkbox using the keyboard
- I've created an unstyled prop but the checkbox doesn't check when unstyled either
- can't uncheck a checked checkbox (I am guessing that we just need to have a callback function to set state, and it won't uncheck right now because that prop is hardcoded, but I was confused by how it's done on octopusthink.com)
- needs tests!

And some less technical stuff:
- themeable values (size, probably)
- see if I can improve visuals
- draft documentation
- bigger touch targets (maybe?)
